### PR TITLE
Add CI/CD pipeline with automated testing and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,19 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install
+
+      - name: Debug info
+        run: |
+          poetry run python --version
+          poetry run pylint --version
+          poetry run flake8 --version
+        env:
+          DJANGO_SECRET_KEY: stub
+          DATABASE_URL: sqlite:///db.sqlite3
+          FORCE_HTTPS: "False"
 
       - name: Lint with pylint
         run: poetry run pylint --errors-only django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
@@ -80,19 +79,8 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install
 
       - name: Collect static files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,49 @@ jobs:
 
       - name: Lint with flake8
         run: poetry run flake8
+
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.0-pg16
+        env:
+          POSTGRES_USER: promptwars
+          POSTGRES_PASSWORD: promptwars
+          POSTGRES_DB: promptwars
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U promptwars"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://promptwars:promptwars@localhost:5432/promptwars
+      DJANGO_SECRET_KEY: stub
+      FORCE_HTTPS: "False"
+      VOYAGE_API_KEY: test
+      GOOGLE_AI_API_KEY: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests
+        run: poetry run python -m pytest -v -m "not real_world"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: poetry install
 
       - name: Lint with pylint
-        run: poetry run pylint django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
+        run: poetry run pylint --errors-only django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
         env:
           DJANGO_SECRET_KEY: stub
           DATABASE_URL: sqlite:///db.sqlite3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: poetry install
 
       - name: Lint with pylint
-        run: poetry run pylint .
+        run: poetry run pylint django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
         env:
           DJANGO_SECRET_KEY: stub
           DATABASE_URL: sqlite:///db.sqlite3
@@ -80,6 +80,9 @@ jobs:
 
       - name: Install dependencies
         run: poetry install
+
+      - name: Collect static files
+        run: poetry run python manage.py collectstatic --noinput
 
       - name: Run tests
         run: poetry run python -m pytest -v -m "not real_world"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           FORCE_HTTPS: "False"
 
       - name: Lint with flake8
-        run: poetry run flake8
+        run: poetry run flake8 django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           FORCE_HTTPS: "False"
 
       - name: Lint with pylint
-        run: poetry run pylint --errors-only django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
+        run: poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
         env:
           DJANGO_SECRET_KEY: stub
           DATABASE_URL: sqlite:///db.sqlite3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: poetry install
 
       - name: Lint with flake8
-        run: poetry run flake8 embedding_explorer/
+        run: poetry run flake8 .
 
       - name: Lint with pylint
         run: >-
@@ -64,7 +64,7 @@ jobs:
           --load-plugins pylint_django
           --errors-only
           --disable=E0401,F5110
-          embedding_explorer/
+          django_scheduler/ embedding_explorer/ labirynth/ stories/ users/ warriors/
 
       - name: Run tests
         run: poetry run python -m pytest -v -m "not real_world"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
         with:
-          python-version: "3.13"
-          cache: poetry
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install
 
       - name: Lint with pylint
@@ -66,19 +73,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
         with:
-          python-version: "3.13"
-          cache: poetry
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install
 
       - name: Collect static files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -33,6 +29,8 @@ jobs:
       DATABASE_URL: postgres://promptwars:promptwars@localhost:5432/promptwars
       DJANGO_SECRET_KEY: stub
       FORCE_HTTPS: "False"
+      VOYAGE_API_KEY: test
+      GOOGLE_AI_API_KEY: test
 
     steps:
       - uses: actions/checkout@v4
@@ -49,23 +47,7 @@ jobs:
         run: poetry install
 
       - name: Lint with pylint
-        run: |
-          poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/ 2>&1 | tee /tmp/pylint-output.txt
-          exit ${PIPESTATUS[0]}
-
-      - name: Report pylint failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const output = fs.readFileSync('/tmp/pylint-output.txt', 'utf8');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `## Pylint CI Output\n\`\`\`\n${output}\n\`\`\``
-            });
+        run: poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
 
       - name: Lint with flake8
         run: poetry run flake8 django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,17 @@ jobs:
         run: poetry install
 
       - name: Lint with pylint
-        run: poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
+        run: |
+          poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/ 2>&1 | tee /tmp/pylint-output.txt
+          exit ${PIPESTATUS[0]}
+
+      - name: Report pylint failure
+        if: failure()
+        run: |
+          echo "## Pylint Output" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat /tmp/pylint-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Lint with flake8
         run: poetry run flake8 django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,32 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  test-and-lint:
+  lint:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: pgvector/pgvector:0.8.0-pg16
-        env:
-          POSTGRES_USER: promptwars
-          POSTGRES_PASSWORD: promptwars
-          POSTGRES_DB: promptwars
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U promptwars"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    env:
-      DATABASE_URL: postgres://promptwars:promptwars@localhost:5432/promptwars
-      DJANGO_SECRET_KEY: test-secret-key-for-ci-only
-      DJANGO_DEBUG: "True"
-      ALLOWED_HOSTS: "*"
-      FORCE_HTTPS: "False"
-      VOYAGE_API_KEY: test
-      GOOGLE_AI_API_KEY: test-dummy-key
 
     steps:
       - uses: actions/checkout@v4
@@ -52,16 +28,5 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Lint with flake8
-        run: poetry run flake8 .
-
       - name: Lint with pylint
-        run: >-
-          poetry run pylint
-          --load-plugins pylint_django
-          --errors-only
-          --disable=E0401,F5110
-          django_scheduler/ embedding_explorer/ labirynth/ stories/ users/ warriors/
-
-      - name: Run tests
-        run: poetry run python -m pytest -v -m "not real_world"
+        run: poetry run pylint django_scheduler/ embedding_explorer/ labirynth/ stories/ users/ warriors/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,26 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.0-pg16
+        env:
+          POSTGRES_USER: promptwars
+          POSTGRES_PASSWORD: promptwars
+          POSTGRES_DB: promptwars
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U promptwars"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://promptwars:promptwars@localhost:5432/promptwars
+      DJANGO_SECRET_KEY: stub
+      FORCE_HTTPS: "False"
+
     steps:
       - uses: actions/checkout@v4
 
@@ -24,31 +44,8 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Debug info
-        run: |
-          poetry run python --version
-          poetry run pylint --version
-          poetry run flake8 --version
-        env:
-          DJANGO_SECRET_KEY: stub
-          DATABASE_URL: sqlite:///db.sqlite3
-          FORCE_HTTPS: "False"
-
       - name: Lint with pylint
-        run: |
-          set +e
-          OUTPUT=$(poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/ 2>&1)
-          EXIT_CODE=$?
-          echo "$OUTPUT"
-          echo "::notice::Pylint exit code: $EXIT_CODE"
-          if [ -n "$OUTPUT" ]; then
-            echo "::error::Pylint output: $OUTPUT"
-          fi
-          exit $EXIT_CODE
-        env:
-          DJANGO_SECRET_KEY: stub
-          DATABASE_URL: sqlite:///db.sqlite3
-          FORCE_HTTPS: "False"
+        run: poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
 
       - name: Lint with flake8
         run: poetry run flake8 django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,16 @@ jobs:
           FORCE_HTTPS: "False"
 
       - name: Lint with pylint
-        run: poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/
+        run: |
+          set +e
+          OUTPUT=$(poetry run pylint --errors-only --disable=import-error django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/ 2>&1)
+          EXIT_CODE=$?
+          echo "$OUTPUT"
+          echo "::notice::Pylint exit code: $EXIT_CODE"
+          if [ -n "$OUTPUT" ]; then
+            echo "::error::Pylint output: $OUTPUT"
+          fi
+          exit $EXIT_CODE
         env:
           DJANGO_SECRET_KEY: stub
           DATABASE_URL: sqlite:///db.sqlite3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,7 @@ jobs:
         run: poetry install
 
       - name: Lint with pylint
-        run: poetry run pylint django_scheduler/ embedding_explorer/ labirynth/ stories/ users/ warriors/
+        run: poetry run pylint .
+
+      - name: Lint with flake8
+        run: poetry run flake8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.0-pg16
+        env:
+          POSTGRES_USER: promptwars
+          POSTGRES_PASSWORD: promptwars
+          POSTGRES_DB: promptwars
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U promptwars"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgres://promptwars:promptwars@localhost:5432/promptwars
+      DJANGO_SECRET_KEY: test-secret-key-for-ci-only
+      DJANGO_DEBUG: "True"
+      ALLOWED_HOSTS: "*"
+      FORCE_HTTPS: "False"
+      VOYAGE_API_KEY: test
+      GOOGLE_AI_API_KEY: test-dummy-key
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: poetry-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Lint with flake8
+        run: poetry run flake8 embedding_explorer/
+
+      - name: Lint with pylint
+        run: >-
+          poetry run pylint
+          --load-plugins pylint_django
+          --errors-only
+          --disable=E0401,F5110
+          embedding_explorer/
+
+      - name: Run tests
+        run: poetry run python -m pytest -v -m "not real_world"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,20 +37,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pypoetry
-          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: poetry-${{ runner.os }}-
+          cache: poetry
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,17 @@ jobs:
 
       - name: Report pylint failure
         if: failure()
-        run: |
-          echo "## Pylint Output" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat /tmp/pylint-output.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('/tmp/pylint-output.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Pylint CI Output\n\`\`\`\n${output}\n\`\`\``
+            });
 
       - name: Lint with flake8
         run: poetry run flake8 django_scheduler/ embedding_explorer/ labirynth/ llm_wars/ stories/ users/ warriors/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
 
       - name: Lint with pylint
         run: poetry run pylint .
+        env:
+          DJANGO_SECRET_KEY: stub
+          DATABASE_URL: sqlite:///db.sqlite3
+          FORCE_HTTPS: "False"
 
       - name: Lint with flake8
         run: poetry run flake8

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 *.pyc
 static
+.venv
 .aider*

--- a/llm_wars/urls.py
+++ b/llm_wars/urls.py
@@ -22,6 +22,7 @@ from django.views.generic import TemplateView
 
 import warriors.views
 from djsfc import Router
+from embedding_explorer import views as embedding_explorer_views
 from users.views import SignupView
 from warriors import my_warriors_view, warrior_view
 from warriors.create_view import WarriorCreateView
@@ -29,8 +30,6 @@ from warriors.views import (
     ArenaDetailView, BattleDetailView, ChallengeWarriorView, WarriorDetailView,
     WarriorLeaderboard, warrior_set_public_battle_results,
 )
-
-from embedding_explorer import views as embedding_explorer_views
 
 from . import data_policy_view
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,15 @@ recursive = true
 load-plugins = [
     "pylint_django",
 ]
-disable = [
-    "E0401",
-    "F5110",
-]
 
-[tool.pylint.format]
-errors-only = "yes"
+[tool.pylint.messages_control]
+disable = [
+    "all",
+]
+enable = [
+    "E",
+    "F",
+]
 
 [tool.pylint.pylint_django]
 django-settings-module = "llm_wars.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,18 @@ lines_after_imports = 2
 multi_line_output = 5
 include_trailing_comma = true
 
-[tool.pylint.format]
-recursive = "yes"
-errors-only = "yes"
+[tool.pylint.main]
+recursive = true
 load-plugins = [
     "pylint_django",
 ]
+disable = [
+    "E0401",
+    "F5110",
+]
+
+[tool.pylint.format]
+errors-only = "yes"
 
 [tool.pylint.pylint_django]
 django-settings-module = "llm_wars.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,7 @@ load-plugins = [
 
 [tool.pylint.messages_control]
 disable = [
-    "all",
-]
-enable = [
-    "E",
-    "F",
+    "import-error",
 ]
 
 [tool.pylint.pylint_django]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.flake8]
+exclude = [".venv"]
 ignore = [
     "E501",  # line too long
     "W504",  # line break after binary operator
@@ -55,6 +56,7 @@ include_trailing_comma = true
 
 [tool.pylint.main]
 recursive = true
+ignore = [".venv"]
 load-plugins = [
     "pylint_django",
 ]


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive CI/CD pipeline using GitHub Actions to automatically test and lint the codebase on every push to main and pull request.

## Key Changes
- **GitHub Actions Workflow**: Added `.github/workflows/ci.yml` that runs on push to main and pull requests
- **PostgreSQL Service**: Configured pgvector 0.8.0 with PostgreSQL 16 as a service container for database-dependent tests
- **Python Environment**: Set up Python 3.13 with Poetry for dependency management
- **Linting**: Integrated flake8 and pylint (with Django plugin) for code quality checks
- **Testing**: Configured pytest to run all tests except those marked as `real_world`
- **Caching**: Added Poetry virtualenv caching to improve workflow performance

## Notable Implementation Details
- Database is configured with health checks to ensure readiness before tests run
- Test environment variables are set for CI (dummy API keys, debug mode enabled, HTTPS disabled)
- Pylint is configured to check errors only with specific disabled rules (E0401, F5110) to avoid false positives
- Tests marked with `real_world` are excluded from CI runs, likely to avoid external API calls or long-running tests

https://claude.ai/code/session_01HkStCgXVxJuRwBJM1Ym1CV