### PR TITLE
Mock embeddings in battle e2e test

### DIFF
--- a/warriors/tests/test_e2e.py
+++ b/warriors/tests/test_e2e.py
@@ -49,6 +49,8 @@ def test_submit_warrior_e2e(client, mocked_recaptcha, monkeypatch, default_arena
 def test_battle_from_warriors_e2e(monkeypatch, warrior_arena, other_warrior_arena):
     assert warrior_arena.rating == 0.0
 
+    monkeypatch.setattr(embeddings, 'get_embedding', mock.MagicMock(return_value=[0.0] * 1024))
+
     completion_mock = mock.MagicMock()
     completion_mock.message.content = 'Some result'
     completion_mock.finish_reason = 'stop'


### PR DESCRIPTION
## Summary
Added mocking of the embeddings service in the battle end-to-end test to ensure consistent test behavior and avoid external dependencies.

## Key Changes
- Mock `embeddings.get_embedding()` to return a fixed vector of 1024 zeros in `test_battle_from_warriors_e2e`
- This prevents the test from making actual calls to the embeddings service during test execution

## Implementation Details
The mock is set up using `monkeypatch.setattr()` before the completion mock, ensuring that any embedding operations during the battle simulation use the mocked implementation rather than real service calls. This improves test reliability and isolation.

https://claude.ai/code/session_01JmQbchZNuxpinRT832WSNT