### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SupraSummus/prompt-wars/security/code-scanning/2](https://github.com/SupraSummus/prompt-wars/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to both jobs (`lint` and `test`) without changing functionality. The minimal required scope for the current steps is `contents: read` (needed for `actions/checkout`). No additional scopes are required based on the provided snippet.

Edit `.github/workflows/ci.yml` near the top-level keys: insert `permissions:` between the `on:` trigger block and `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
