### PR TITLE
Improve guess ordering and add data policy warning

### DIFF
--- a/guessing/views.py
+++ b/guessing/views.py
@@ -68,7 +68,9 @@ def _render_guess_row(guess):
 
 
 def _build_detail_page(request, target, form_instance):
-    guesses = list(_annotated_guesses(target, request.user))
+    annotated = _annotated_guesses(target, request.user)
+    guesses = list(annotated)
+    last_guess = annotated.order_by('-created_at').first()
 
     main_el = main(cls="container")
     with main_el:
@@ -90,8 +92,13 @@ def _build_detail_page(request, target, form_instance):
             raw(form_instance.as_div())
             button("Submit Guess", type="submit")
 
+        if last_guess is not None:
+            h2("Last guess")
+            with ul():
+                _render_guess_row(last_guess)
+
         if guesses:
-            h2("Guesses")
+            h2("All guesses")
             with ul():
                 for guess in guesses:
                     _render_guess_row(guess)

--- a/guessing/views.py
+++ b/guessing/views.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.decorators import login_required
+from django.db.models import F
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect
@@ -43,7 +44,7 @@ def _annotated_guesses(target, user):
         .filter(target=target, user=user)
         .select_related('query')
         .annotate(distance=HammingDistance('query__embedding', target.embedding))
-        .order_by('distance')
+        .order_by(F('distance').asc(nulls_first=True))
     )
 
 
@@ -81,6 +82,11 @@ def _build_detail_page(request, target, form_instance):
             action=reverse('guessing:guess_post', kwargs={'target_id': target.id}),
         ):
             input_(type="hidden", name="csrfmiddlewaretoken", value=get_token(request))
+            with strong():
+                raw(
+                    "Don't share any private, secret, or classified information! "
+                    f'See <a href="{reverse("data_policy:root")}">Data policy</a>'
+                )
             raw(form_instance.as_div())
             button("Submit Guess", type="submit")
 


### PR DESCRIPTION
## Summary
This PR improves the guess ordering logic and adds a data policy warning to the guess submission form.

## Key Changes
- **Enhanced guess ordering**: Updated `_annotated_guesses()` to use `F('distance').asc(nulls_first=True)` instead of simple `order_by('distance')`. This ensures explicit null handling, placing null distances first in the result set.
- **Data policy warning**: Added a prominent warning message to the guess submission form that discourages users from sharing private, secret, or classified information, with a link to the data policy page.

## Implementation Details
- The ordering change uses Django's `F` expressions for more explicit control over null value placement in the query results.
- The warning is displayed in a `<strong>` tag within the form, making it visually prominent to users before they submit their guess.
- The data policy link is dynamically generated using the `reverse()` function to reference the `data_policy:root` URL.

https://claude.ai/code/session_01G6KHKtYCqjXQHSgPRPZ8js