### PR TITLE
Add project conventions and documentation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,108 @@
-# Running tests in Claude Code web environment
+# AGENTS.md
+
+Agent-facing project doc.
+`CLAUDE.md` in the repo root is a symlink to this file,
+so both names resolve to the same content —
+different tools look for different filenames.
+Edit either, you edit both.
+
+## Docs must not repeat what the code already says
+
+A doc paragraph that restates code behavior —
+a scoring formula, a matchmaking rule, a config default —
+is a second copy that goes stale silently,
+and the reader can't tell which copy is authoritative.
+Split by ownership:
+
+- **Code (comments/docstrings)** owns "what is implemented and how".
+  Battle resolution, scoring, and matchmaking live in `warriors/`
+  (`battles.py`, `score.py`, `lcs.py`, `random_matchmaking.py`);
+  if you're about to write a doc paragraph describing behavior,
+  put the one-or-two-sentence rationale in a docstring or comment
+  at the source and have the doc point at the file or function by name.
+- **Docs (`README.md`, `CONCEPT.md`, `docs/`)** own what code cannot show:
+  the game's design goals and philosophy (`docs/parallels.md`),
+  decisions and their rationale,
+  what is deliberately *not* implemented and why,
+  observed player strategies and emergent behavior,
+  and planned work and open questions
+  (`docs/lineages.md` is a design proposal, not shipped code —
+  that's exactly the kind of content that belongs in a doc).
+
+Cross-references go by name:
+docs name files, functions, and models;
+a code comment whose "why" spans modules
+points at a doc section by heading.
+When renaming a doc heading or a named item,
+grep the other side for references to it.
+
+Don't paste code or values into docs —
+formulas, constants, payload shapes.
+Link to the item instead;
+a pasted copy is guaranteed to drift.
+
+## Docs describe the present; git owns the past
+
+A doc that narrates its own evolution is a changelog,
+and git already keeps a better one.
+The test for any sentence about the past:
+does it change what a reader working on the current system should do?
+If it only records that something happened or used to be different, delete it;
+if it explains why the present is the way it is,
+keep it — phrased as present-tense rationale, not as an event.
+A rejected alternative and why it was rejected earns its place
+(it stops the next person from re-proposing it);
+done markers, "now implemented" status narration,
+and dates that only order the doc's own edits are deadweight.
+When a decision changes, rewrite the owning section in place —
+don't append an amendment that readers must apply mentally.
+A word-level tell: temporal adverbs —
+"still", "now", "not yet", "no longer" —
+anchor a sentence to the moment it was written;
+write the plain present instead.
+
+## Tracking debt you notice in passing
+
+When you spot a rough edge while working on something else —
+a refactor, a dead branch, drifted duplication, a missing test —
+log it in `TODO.md` at the repo root
+instead of fixing it now (scope creep)
+or burying an inline `# TODO` (invisible outside that file).
+Glance at `TODO.md` before starting new work;
+its header has the convention.
+Game-design ideas and philosophical observations are not debt:
+they go to `CONCEPT.md` or `docs/`, next to their rationale.
+
+## Prose uses semantic line breaks
+
+Write natural-language text —
+this file, `README.md`, `CONCEPT.md`, `docs/`, commit bodies —
+using [semantic line breaks](https://sembr.org):
+start a new source line after each sentence,
+and after independent clauses set off by a comma,
+semicolon, colon, or em dash.
+Markdown joins these lines with a space on render,
+so the output is unchanged;
+what it buys is diffs that land on the clause that changed
+rather than reflowing a whole paragraph.
+Adopt this lazily:
+leave existing prose alone,
+but reformat any paragraph you touch as part of the edit.
+Don't reflow whole documents just to convert them.
+
+## Git
+
+Commit messages: focus on "why", not "what" — "what" is in the diff.
+Keep the subject short: aim for ≤50 characters, hard limit 72.
+Prefer a terse imperative over a full sentence;
+if it doesn't fit, move detail to the body.
+
+## Running tests in Claude Code web environment
 
 The web environment has Python 3.11 as the default, but the project requires
 Python 3.13. PostgreSQL 16 is available but needs to be started manually.
 
-## Setup
+### Setup
 
 ```bash
 # Start PostgreSQL
@@ -42,14 +141,14 @@ pip install poetry
 poetry install
 ```
 
-## Running tests
+### Running tests
 
 ```bash
 cd /home/user/prompt-wars
 poetry run python -m pytest embedding_explorer/tests.py -v
 ```
 
-## Linting
+### Linting
 
 ```bash
 cd /home/user/prompt-wars

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,53 @@
+# TODO
+
+A running registry of open technical debt —
+things worth improving but outside the scope
+of whatever is currently being worked on.
+Spot a rough edge while working on something else —
+a sketchy pattern, a dead branch, drifted duplication, a missing test?
+Log it here instead of fixing it inline (scope creep)
+or burying a `# TODO` in code (invisible outside that file).
+Glance at this file before starting new work;
+it doubles as a map of where the rough edges are.
+
+Registry, not changelog:
+when an entry is resolved — or turns out to be wrong or outdated —
+delete it in the same commit.
+Never strike it through or mark it "done";
+git history is the changelog.
+The file only ever contains open items.
+
+One paragraph per entry, separated by blank lines —
+no bullets, no numbering, no headings.
+Adding or removing an entry then yields a clean, minimal diff
+that doesn't reflow its neighbors.
+Write each entry concretely enough that someone can pick it up cold,
+and name a concrete next move — what the fix would actually look like.
+"Verify someday" is a hope, not a next move.
+
+Belongs here: refactors, dead code, inconsistencies,
+missing tests, sketchy patterns.
+Does not: game-design ideas and open design questions —
+those live in `CONCEPT.md` or `docs/`, next to their rationale.
+Prefer behavior-preserving noticings;
+when an entry implies a behavior change, say so,
+since it will need sign-off.
+
+---
+
+`CONCEPT.md` restates the battle mechanics implemented in `warriors/` —
+the prompt-concatenation flow, the LCS scoring steps,
+and the normalization formula —
+against the "docs must not repeat what the code already says" rule
+in `AGENTS.md`
+(adopted after the doc was written,
+so this is expected backlog, not a violation).
+The copies have already drifted:
+the doc presents LCS as the only scoring,
+while `warriors/score.py` has a second `EMBEDDINGS` algorithm
+selectable per arena (`Arena.score_algorithm`).
+Next move: keep the concept-level narrative
+("make the LLM reproduce your text while ignoring the opponent's")
+and move the mechanical detail into docstrings at the source,
+leaving the doc pointing at `warriors/battles.py`
+and `warriors/score.py` by name.


### PR DESCRIPTION
Establish and document project conventions for documentation, code organization, and git practices.

## Summary

This change introduces two new foundational documents that codify how the project should be maintained going forward:

- **AGENTS.md**: A comprehensive guide for contributors on documentation standards, code ownership, and prose style. This file is symlinked as CLAUDE.md so both names resolve to the same content.
- **TODO.md**: A registry for tracking open technical debt and rough edges discovered during development.

## Key Changes

- **AGENTS.md** establishes clear separation of concerns:
  - Code (comments/docstrings) owns implementation details and the "how"
  - Docs own design philosophy, decisions, and rationale
  - Eliminates duplication by requiring docs to reference code by name rather than restating behavior
  
- **Documentation principles**:
  - Docs describe the present; git owns the past (no changelogs or temporal narration in docs)
  - Semantic line breaks for diffs that land on changed clauses, not reflowed paragraphs
  - Cross-references by name between code and docs for maintainability

- **Git and commit practices**:
  - Commit messages focus on "why" not "what"
  - Subject line target: ≤50 characters, hard limit 72
  - Prefer terse imperative form

- **TODO.md** provides a lightweight system for tracking debt:
  - One paragraph per entry (no bullets, no numbering)
  - Entries deleted when resolved, never struck through
  - Concrete next moves required; vague aspirations excluded
  - Distinguishes between technical debt (belongs here) and design ideas (belong in CONCEPT.md/docs/)

- **Existing test documentation** reorganized under a "Running tests in Claude Code web environment" section with proper heading hierarchy

## Notable Details

The diff includes a concrete example in TODO.md documenting existing drift in CONCEPT.md around the scoring algorithms, with a specific next move: consolidate mechanical details into docstrings and have docs point to source by name.

https://claude.ai/code/session_01P7QNUbeqji2k8ad9XwMZrk