### PR TITLE
Embed scheduler in worker process with stop_event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,10 @@ sudo -u postgres psql -c "CREATE DATABASE promptwars OWNER promptwars;"
 
 # Upgrade pgvector to >= 0.7.0 (system package is 0.6.0, too old)
 # Required for HammingDistance on BitField (the <~> operator on bit type).
+# Only tests that run HammingDistance queries need this (embedding_explorer,
+# guessing); for everything else the system package alone is enough
+# (migrations only CREATE EXTENSION vector), and the source build below
+# takes several minutes — skip it when not testing those apps.
 apt-get install -y postgresql-16-pgvector postgresql-server-dev-16
 cd /tmp && git clone --branch v0.8.0 --depth 1 https://github.com/pgvector/pgvector.git
 cd /tmp/pgvector && make && make install

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 postdeploy: python manage.py migrate --no-input
 web: gunicorn llm_wars.wsgi
-worker: python manage.py goals_threaded_worker --threads 4
-scheduler: python manage.py scheduler
+worker: python manage.py worker --threads 4

--- a/TODO.md
+++ b/TODO.md
@@ -55,3 +55,13 @@ Next move: keep the concept-level narrative
 and move the mechanical detail into docstrings at the source,
 leaving the doc pointing at `warriors/battles.py`
 and `warriors/score.py` by name.
+
+`warriors/rating_tests.py::test_get_performance_rating` is flaky:
+`get_performance_rating` in `warriors/rating.py` seeds its optimizer
+with an unseeded `np.random.uniform` starting position,
+so the test intermittently converges to a different optimum
+and misses its `pytest.approx(2550.5, abs=0.1)` assertion
+(observed failing in a full-suite run, passing in isolation).
+Next move: seed the RNG in the test
+(e.g. `np.random.seed` in a fixture)
+or pass an explicit `rating_guess` so the outcome is deterministic.

--- a/django_scheduler/models.py
+++ b/django_scheduler/models.py
@@ -1,7 +1,7 @@
 import datetime
 import inspect
 import logging
-import time
+import threading
 import uuid
 from dataclasses import dataclass
 from typing import Callable
@@ -46,7 +46,11 @@ def get_job_from_function(handler, interval, key=None):
     return LocalJob(key=key, handler=handler, interval=interval)
 
 
-def run(local_jobs=None, blocking=True):
+def run(local_jobs=None, blocking=True, stop_event=None):
+    # stop_event lets a host process (see the worker management command)
+    # stop the loop cleanly from another thread.
+    if stop_event is None:
+        stop_event = threading.Event()
     if local_jobs is None:
         global _local_jobs  # noqa: F824
         local_jobs = _local_jobs.copy()
@@ -70,7 +74,7 @@ def run(local_jobs=None, blocking=True):
     logger.info("Starting scheduler. Jobs: %s", [job.key for _, job in queue])
 
     # run jobs
-    while True:
+    while not stop_event.is_set():
         now = timezone.now()
         if not queue:
             logger.info("No jobs in queue, exiting")
@@ -83,7 +87,9 @@ def run(local_jobs=None, blocking=True):
                 break
             time_to_sleep = (next_run - now).total_seconds()
             logger.info("Sleeping for %s seconds until next job %s", time_to_sleep, local_job.key)
-            time.sleep(time_to_sleep)
+            if stop_event.wait(time_to_sleep):
+                logger.info("Stop requested, exiting")
+                break
 
         next_run, local_job = queue.pop(0)
         db_job = run_job(local_job)

--- a/django_scheduler/models_tests.py
+++ b/django_scheduler/models_tests.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 from datetime import timedelta
 from unittest.mock import Mock
@@ -120,4 +121,49 @@ def test_non_blocking_exits_early(caplog):
     )
 
     run([local_job], blocking=False)
+    assert not handler.called
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stop_event_interrupts_sleep():
+    """Setting stop_event wakes the scheduler from its sleep and exits the loop"""
+    Job.objects.create(
+        key="future_job",
+        last_run=timezone.now(),
+    )
+    handler = Mock()
+    local_job = LocalJob(
+        key="future_job",
+        handler=handler,
+        interval=timedelta(hours=1),
+    )
+    stop_event = threading.Event()
+
+    thread = threading.Thread(
+        target=run,
+        args=([local_job],),
+        kwargs={"stop_event": stop_event},
+    )
+    thread.start()
+    stop_event.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert not handler.called
+
+
+@pytest.mark.django_db
+def test_pre_set_stop_event_exits_immediately():
+    """A stop_event set before run() skips even due jobs"""
+    handler = Mock()
+    local_job = LocalJob(
+        key="due_job",
+        handler=handler,
+        interval=timedelta(minutes=30),
+    )
+    stop_event = threading.Event()
+    stop_event.set()
+
+    run([local_job], stop_event=stop_event)
+
     assert not handler.called

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -25,13 +25,14 @@ not because the project bleeds without it.
 Where the money actually goes, in order:
 
 1. **Fixed compute, lightly loaded.**
-   Three always-on containers serve a workload of roughly one battle
-   every three minutes.
+   Two always-on containers serve a workload of roughly one battle
+   every three minutes
+   (the scheduler runs inside the worker process —
+   see the `worker` command in `warriors/management/commands/`
+   and `Procfile`).
    Lever: smaller container sizes
    (the constraint is process memory, not load —
-   downsize per-container and watch the metrics),
-   and merging the `scheduler` process into the `worker`
-   (see `Procfile` and `django_scheduler`) to drop a container entirely.
+   downsize per-container and watch the metrics).
 2. **Reasoning tokens — an expense, but a deliberate one.**
    Battle resolution pays for model thinking that never appears in output:
    the Gemini thinking budget in `warriors/llms/google.py`

--- a/warriors/management/commands/worker.py
+++ b/warriors/management/commands/worker.py
@@ -1,0 +1,71 @@
+"""
+Single entry point for all background work.
+
+Two task systems share this process by design:
+django_goals executes one-shot goals with retries and preconditions
+(battles, embeddings), django_scheduler ticks fixed-interval jobs.
+Unifying them — ticks as self-rescheduling goals — is rejected:
+the busiest ticks fire every second (see warriors/scheduler.py),
+and pushing a goal row through the goals machinery every second
+is churn without simplification.
+"""
+import os
+import signal
+import threading
+
+from django.core.management.base import BaseCommand
+from django_goals.management.commands.goals_busy_worker import (
+    stop_signal_handler,
+)
+from django_goals.management.commands.goals_threaded_worker import (
+    threaded_worker,
+)
+
+from django_scheduler.models import run as run_scheduler
+
+
+class Command(BaseCommand):
+    help = 'Run the goals worker and the scheduler in one process'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--threads', type=int, default=1)
+        parser.add_argument(
+            '--once',
+            action='store_true',
+            help='Exit when no work is available',
+        )
+
+    def handle(self, *args, **options):
+        # One process instead of dedicated worker and scheduler containers
+        # (docs/strategy.md, fixed compute). Multiple instances are safe:
+        # scheduler jobs lock their DB row (see run_job).
+        with stop_signal_handler() as stop_event:
+            scheduler_thread = threading.Thread(
+                target=self._run_scheduler,
+                args=(stop_event,),
+                name='scheduler',
+            )
+            scheduler_thread.start()
+            try:
+                threaded_worker(
+                    worker_specs=[(options['threads'], None)],
+                    stop_event=stop_event,
+                    once=options['once'],
+                )
+            finally:
+                # in --once mode the worker exits on its own;
+                # the scheduler has no such mode, so stop it explicitly
+                stop_event.set()
+                scheduler_thread.join()
+
+    @staticmethod
+    def _run_scheduler(stop_event):
+        try:
+            run_scheduler(stop_event=stop_event)
+        finally:
+            if not stop_event.is_set():
+                # The scheduler died while worker threads live on.
+                # A dedicated scheduler container would be restarted
+                # by the platform; stopping the whole process keeps
+                # that supervision.
+                os.kill(os.getpid(), signal.SIGTERM)

--- a/warriors/tests/test_worker_command.py
+++ b/warriors/tests/test_worker_command.py
@@ -1,0 +1,32 @@
+import signal
+import threading
+from unittest.mock import Mock
+
+import pytest
+
+from warriors.management.commands import worker
+
+
+def test_scheduler_death_stops_the_process(monkeypatch):
+    """A crashed scheduler must take the process down for the platform to restart"""
+    monkeypatch.setattr(worker, 'run_scheduler', Mock(side_effect=Exception('boom')))
+    kill = Mock()
+    monkeypatch.setattr(worker.os, 'kill', kill)
+
+    with pytest.raises(Exception, match='boom'):
+        worker.Command._run_scheduler(threading.Event())
+
+    kill.assert_called_once_with(worker.os.getpid(), signal.SIGTERM)
+
+
+def test_requested_stop_does_not_kill_the_process(monkeypatch):
+    """Normal shutdown must not SIGTERM a process that is already stopping"""
+    monkeypatch.setattr(worker, 'run_scheduler', Mock())
+    kill = Mock()
+    monkeypatch.setattr(worker.os, 'kill', kill)
+    stop_event = threading.Event()
+    stop_event.set()
+
+    worker.Command._run_scheduler(stop_event)
+
+    kill.assert_not_called()


### PR DESCRIPTION
Merge the scheduler into the worker process to drop one of three always-on containers — the first cost lever in `docs/strategy.md`.

**Key changes:**

- Add an optional `stop_event` parameter to `django_scheduler.models.run()`: the sleep between jobs becomes `Event.wait()`, so a host process can stop the loop cleanly from another thread. Behavior without the argument is unchanged.
- New `worker` management command composes the `django_goals` building blocks directly (`threaded_worker` + `stop_signal_handler`) instead of subclassing the third-party command: one signal-driven stop event is shared by the worker threads and the scheduler thread, so SIGTERM stops both concurrently.
- Supervision is preserved: if the scheduler thread dies while the worker lives on, the command SIGTERMs the whole process so the platform restarts it — a dedicated scheduler container would have gotten that restart for free.
- `Procfile` runs `worker --threads 4`; the separate `scheduler` process line is gone (the standalone `scheduler` command remains for one-off runs).
- Tests: stop-event semantics in `django_scheduler/models_tests.py` (wake mid-sleep, pre-set event wins over due jobs) and the supervision contract in `warriors/tests/test_worker_command.py`.
- `docs/strategy.md` fixed-compute bullet rewritten to the present state; `TODO.md` gains an entry for a flaky rating test noticed while running the suite; `AGENTS.md` notes when the slow pgvector source build is skippable in web sessions.

**After deploy:** verify on Scalingo that the `scheduler` container is scaled to zero — that's where the saving lands. Deploy overlap is safe: scheduler jobs coordinate via `select_for_update` on their `Job` row.

https://claude.ai/code/session_01QWiuqY11AJn9DQetqtA3yj