### PR TITLE
Document design tensions, rounds proposal, and cost levers

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -107,6 +107,9 @@ Different LLMs require different approaches:
 Development priorities, their rationale,
 and the alternatives that were considered and rejected
 live in [docs/strategy.md](docs/strategy.md);
+design-level strengths, tensions, and candidate directions
+in [docs/design-tensions.md](docs/design-tensions.md);
+the fixed-cadence rounds proposal in [docs/rounds.md](docs/rounds.md);
 this doc stays about the game's concept and mechanics.
 
 ## Developer Engagement

--- a/docs/design-tensions.md
+++ b/docs/design-tensions.md
@@ -1,0 +1,125 @@
+# Design tensions and directions
+
+This doc owns a design-level reading of the game:
+what it does well,
+where the mechanics work against its own appeal,
+and the candidate directions that follow.
+Mechanics live in code (`warriors/`);
+effort priorities live in `docs/strategy.md`;
+the fixed-cadence rounds proposal has its own doc,
+`docs/rounds.md`.
+
+## Strengths
+
+**Anonymous intimacy.**
+A player's thought is fused with a stranger's thought
+by a third mind — the LLM as mediator —
+without either player performing socially.
+It is talking to strangers with the awkwardness removed.
+Two limits:
+the game offers exactly one relationship to the stranger (combat),
+and the fusion happens while players are away
+and is shown to nobody
+(the discarded retention signal in `docs/strategy.md`
+is this same gap seen from the funnel side).
+
+**Emergent gems.**
+Battle outputs are sometimes funny or genuinely surprising,
+and watching nondeterministic paths unfold is a real pleasure —
+but most outputs are boring,
+and the gems are buried in the pile.
+This is a curation gap, not a generation gap:
+every output gets an embedding,
+so novelty is measurable
+as distance from the cloud of prior outputs,
+yet nothing ranks or surfaces it.
+The only related control, `Warrior.public_battle_results`,
+is a visibility flag, not a taste signal;
+nobody can mark an output as good.
+
+**A living system.**
+The universe of submitted prompts grows
+and becomes more diverse —
+in span, not in uniformity of distribution.
+But the system has no memory and no narrator:
+no map of prompt space,
+no lineage records
+(`docs/lineages.md` is the unimplemented proposal),
+no visible history of meta shifts.
+A living world that cannot be observed
+reads as a static leaderboard.
+
+## The central tension: dominance selects against delight
+
+A perfect score means the output is the winning prompt verbatim.
+The documented meta strategies (`CONCEPT.md`)
+are all ways of making the output maximally boring:
+a lone rare emoji, a canned refusal, a one-line protocol response.
+The interesting outputs — real fusions of two prompts —
+come from balanced mid-ladder battles,
+precisely the ones the rating system treats as unremarkable draws.
+The fitness function breeds interestingness out of the population.
+
+The open redesign question:
+what does a score look like that rewards
+surviving *interestingly* rather than replicating sterilely?
+`cooperation_score` in `warriors/score.py`
+measures the fusion-quality axis
+(see its docstring),
+is displayed as an experimental table row,
+and feeds no mechanic.
+
+## Further weaknesses
+
+Zero-sum is the only verb:
+everything a player can do is attack.
+The core loop is illegible to newcomers:
+LCS, normalization, two directions, and two scoring algorithms
+stand between a first-time player and the first "aha",
+and a first loss to an emoji-cheese warrior teaches nothing.
+Players have no stakes in battles they didn't initiate:
+matches fire on a schedule against strangers nobody chose,
+with no way even to watch a rival.
+
+## Directions, ranked by leverage
+
+1. **Novelty surfacing.**
+   Rank outputs by embedding distance from the existing corpus;
+   surface a feed of notable battles.
+   This attacks the buried-gems problem
+   with data the system pays for anyway,
+   and provides the content engine
+   for the digest email and the shareable meta-report
+   in `docs/strategy.md`.
+2. **Adopt-an-output.**
+   One click turns a battle result into a warrior.
+   This makes the competition-creation duality
+   in `docs/parallels.md` a playable verb,
+   and makes lineage explicit at creation time —
+   removing the need for the fuzzy-matching reconstruction
+   that `docs/lineages.md` proposes.
+   Adoption count is also a fame metric that rewards generativity:
+   "my warrior's children are everywhere"
+   points the opposite way from sterile dominance.
+3. **A second leaderboard axis.**
+   Keep the dominance rating untouched;
+   add a parallel ranking fed by output novelty and adoption counts.
+   Embedding-based novelty is much harder to goodhart
+   than an LLM interestingness judge,
+   which players would hijack immediately
+   (the data–instruction separation theme in `docs/parallels.md`).
+4. **A cooperative mode.**
+   Two strangers' prompts scored on fusion quality
+   (`cooperation_score`) instead of dominance —
+   the stranger-mixing strength as a duet rather than a duel.
+   Deliberately parked:
+   `docs/strategy.md` rejects new game modes
+   before retention exists,
+   and that reasoning holds here.
+
+The through-line is a single move:
+stop discarding selection signals the system emits.
+Novelty (embeddings),
+lineage (players copy-paste battle results by hand),
+and cooperation (scored but hidden)
+all exist with no surface and no consequence.

--- a/docs/rounds.md
+++ b/docs/rounds.md
@@ -1,0 +1,96 @@
+# Rounds: fixed-cadence mass battles
+
+A proposal, not shipped code:
+run battles in synchronized rounds at a fixed interval —
+daily, say — alongside or eventually instead of
+the continuous trickle.
+Players lock in warriors before a submission deadline,
+the round resolves as one mass job,
+and results are revealed at a fixed hour.
+
+## What a shared clock buys
+
+The strongest effect is not volume but simultaneity.
+Under the continuous trickle,
+every player lives in a private asynchronous stream;
+no two players share a "now".
+A round creates one:
+today's results are a single object everyone saw,
+a natural cadence for the digest email
+(`docs/strategy.md`, retention priority),
+a discussion object,
+and a unit of history —
+metas rise and die in numbered rounds,
+which gives the living system
+the memory and narrator it lacks
+(see the living-system strength in `docs/design-tensions.md`).
+This is the mechanism behind daily-puzzle games:
+scarcity plus synchronization.
+A deadline drives action
+in a way an always-open door does not,
+and a fixed reveal hour makes results an event to anticipate.
+
+## What it does not buy
+
+Per-battle unexpectedness does not increase:
+same prompts, same models, same mechanic.
+What increases is correlated reading —
+twenty outputs from the same night
+make the weird one stand out.
+But a daily pile is exactly as unreadable
+as a trickle of the same size;
+the round needs an editor.
+Rounds are the cadence;
+the novelty-surfacing direction in `docs/design-tensions.md`
+is the editor;
+each is weak without the other.
+
+## Hard requirement: keep the fast lane
+
+The minute-scale first-battle loop is deliberate
+(`get_next_battle_delay` in `warriors/random_matchmaking.py`
+front-loads a fresh warrior's first games)
+and it serves the one funnel stage that works:
+anonymous drive-by visitors create warriors
+because they see them fight immediately.
+"Come back tomorrow at 18:00" loses those players.
+So rounds must not replace instant battles for fresh warriors:
+keep immediate exhibition or placement matches
+(synchronous API, unrated or lightly rated),
+and make the round the rated league.
+The split doubles as a claim-flow prompt —
+"your warrior enters tonight's round;
+leave an email to get the results" —
+and it is the same seam the cost analysis wants
+(see the LLM pricing levers in `docs/strategy.md`:
+fresh warriors on the synchronous path,
+the scheduled mass on batch pricing,
+with the fixed reveal hour hiding
+the batch APIs' variable turnaround entirely).
+
+## Shape and participation
+
+Massive should mean simultaneous, not numerous:
+Swiss-style pairing with a few opponents
+per participating warrior per round
+keeps cost linear and tunable.
+The exponential backoff schedule translates naturally —
+veterans fight every 2^k rounds —
+or participation can require periodic re-confirmation,
+which doubles as a retention touchpoint
+and prunes dead warriors.
+One global reveal hour has timezone politics;
+choose it for where the game's communities live,
+and accept the fixed hour as part of the ritual.
+
+## De-risking path
+
+Add, don't replace:
+a nightly opted-in league round with a morning round report,
+built on the batch pipeline,
+while the trickle continues unchanged.
+If the round page and the digest show a pulse,
+dial the trickle down toward exhibition-only.
+Every step is reversible,
+and the batch infrastructure is shared
+with the status quo either way.

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -45,10 +45,25 @@ Where the money actually goes, in order:
    (see the data–instruction separation theme in `docs/parallels.md`).
    The thinking budget is a game-design dial that happens to cost money,
    priced at roughly €15–20/month for a smarter adversary.
-   Lever that leaves the referee untouched: batch APIs —
-   both Google and OpenAI price batch requests at half,
-   and battles are async, retry-tolerant, and latency-irrelevant,
-   so the workload fits batching exactly.
+   Levers that leave the referee untouched: discounted pricing tiers.
+   OpenAI's flex service tier
+   (in beta — verify model coverage before relying on it)
+   halves the price of the same synchronous call —
+   nearly free to adopt
+   (one request parameter plus capacity-retry handling
+   of the kind `warriors/tasks.py` already does).
+   Batch APIs (Google and OpenAI, also half price)
+   fit most of the workload —
+   battles are async and retry-tolerant —
+   but not the fresh-warrior window:
+   a new warrior's first games arrive within minutes by design
+   (`get_next_battle_delay` in `warriors/random_matchmaking.py`),
+   while batch turnaround is best-effort within 24 hours.
+   Gemini has no flex equivalent,
+   so its half-price path needs either an eligibility split
+   (batch only the battles between warriors past the fast window)
+   or the rounds redesign (`docs/rounds.md`),
+   which turns the scheduled mass into the canonical batch workload.
 3. **Everything else is noise.**
    Visible input/output tokens across ~30k LLM calls per month
    cost less than a coffee.
@@ -89,9 +104,11 @@ it is a signal the system already emits and currently discards.
 
 ## Direction and priority order
 
-1. **Cost levers first** (container sizes, worker/scheduler merge,
-   batch APIs) — the ones that leave gameplay untouched.
-   The infra levers are hours of work; batching is a small project.
+1. **Cost levers first** (container sizes, flex and batch pricing) —
+   the ones that leave gameplay untouched.
+   Container sizing and flex are hours of work;
+   batching is a small project
+   constrained by the fresh-warrior window (see above).
    Together they halve the burn and remove the anxiety
    that distorts every other decision.
 2. **Close the retention loop for players we already get.**

--- a/warriors/random_matchmaking.py
+++ b/warriors/random_matchmaking.py
@@ -123,6 +123,12 @@ def get_next_battle_delay(warrior_arena):
     """
     Get delay to the game N+1, where N is the number of games with this warrior.
     Games are exponentially less and less frequent.
+
+    The front-loaded start is deliberate:
+    a fresh warrior fights within minutes,
+    and that instant feedback is what makes drive-by creation work
+    (see "keep the fast lane" in docs/rounds.md
+    before slowing this down).
     """
     K = 2
     time_unit = datetime.timedelta(minutes=1)

--- a/warriors/score.py
+++ b/warriors/score.py
@@ -236,6 +236,16 @@ class GameScoreViewpoint:
 
     @property
     def cooperation_score(self):
+        """
+        Fusion quality, as opposed to who won:
+        high when both prompts survive into the output in balance
+        (the smaller-to-larger similarity ratio)
+        and are distinct to begin with —
+        the ``1 - warriors_similarity`` factor zeroes out mutual copying,
+        where balanced survival would be trivial.
+        For why this axis matters, see "The central tension"
+        in docs/design-tensions.md.
+        """
         if (
             self.warriors_similarity is None or
             self.warrior_1_similarity is None or


### PR DESCRIPTION
Add three new design docs and update existing ones to clarify the game's strategic direction and open questions.

**New documentation:**
- `docs/design-tensions.md`: Analysis of the game's strengths (anonymous intimacy, emergent gems, living system) and core tension between dominance-based scoring and interestingness. Proposes four candidate directions ranked by leverage: novelty surfacing, adopt-an-output, a second leaderboard axis, and cooperative mode.
- `docs/rounds.md`: Detailed proposal for fixed-cadence synchronized battles (daily rounds) as an alternative to continuous trickle. Explains what rounds buy (shared narrative, event-driven engagement, history), what they don't (per-battle unexpectedness), and the hard requirement to preserve the fast lane for fresh warriors.

**Updates to existing docs:**
- `docs/strategy.md`: Clarify cost levers. Replace vague "batch APIs" with concrete options: OpenAI flex tier (synchronous, half price, low adoption cost) and batch APIs (async, half price, but incompatible with fresh-warrior fast window). Explain how the rounds redesign (`docs/rounds.md`) solves the Gemini batching constraint. Reorder priorities to emphasize cost levers first.
- `CONCEPT.md`: Add cross-references to the three design docs, establishing them as the canonical homes for design rationale, proposals, and strategic decisions.

**Code documentation:**
- `warriors/score.py`: Add docstring to `cooperation_score` explaining fusion quality as an alternative axis to dominance, with reference to the central tension in `docs/design-tensions.md`.
- `warriors/random_matchmaking.py`: Expand `get_next_battle_delay` docstring to explain why the front-loaded schedule is deliberate and reference the "keep the fast lane" constraint in `docs/rounds.md`.

These changes establish the design conversation at the doc level without altering gameplay or mechanics, following the convention that docs own "what is deliberately not implemented and why" and "planned work and open questions."

https://claude.ai/code/session_01QtcRbm8BrSvNhAmHH8PX8V