### PR TITLE
Link legacy DBGame rows to battles via backfill command

### DIFF
--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -65,13 +65,22 @@ rolling back a reader flip is a code revert with no data repair.
 ### 1. Link games to their battle
 
 Add a nullable `battle` foreign key to `DBGame`,
-written in `Battle.create_from_warriors`;
-backfill historical rows by the (llm, warriors, scheduled_at) match
-the backfill script already uses —
+written in `Battle.create_from_warriors`
+and guarded from day one by a unique (battle, warrior_1) constraint,
+which null rows are exempt from.
+Historical rows are linked out-of-band
+by the `backfill_game_battles` management command,
+matching on (llm, warriors, scheduled_at) —
 the same triple rejected above as a pairing *key*,
 acceptable for a one-time match because
-enforcing not-null and unique (battle, warrior_1) right after
-surfaces any ambiguous rows for manual resolution.
+making the column not-null once the backfill has run clean
+surfaces any unmatched rows for manual resolution.
+The backfill is a command rather than a data migration
+because at production scale (hundreds of thousands of games)
+it must not hold a table lock inside a deploy;
+the command batches and can be interrupted and rerun.
+The not-null enforcement is its own follow-up migration,
+shipped only after the production backfill reports zero unlinked rows.
 This replaces implicit pairing with an explicit one
 *before* anything starts reading game rows,
 and lets `resolve_battle` locate its game by battle and direction

--- a/tmp.py
+++ b/tmp.py
@@ -20,6 +20,7 @@ while True:
             warrior_2=battle.warrior_2,
             scheduled_at=battle.scheduled_at,
             defaults={
+                'battle': battle,
                 'input_sha256': battle.input_sha256_1_2,
                 'text_unit': battle.text_unit_1_2,
                 'finish_reason': battle.finish_reason_1_2,
@@ -39,6 +40,7 @@ while True:
             warrior_2=battle.warrior_1,
             scheduled_at=battle.scheduled_at,
             defaults={
+                'battle': battle,
                 'input_sha256': battle.input_sha256_2_1,
                 'text_unit': battle.text_unit_2_1,
                 'finish_reason': battle.finish_reason_2_1,

--- a/warriors/battles.py
+++ b/warriors/battles.py
@@ -210,6 +210,7 @@ class Battle(models.Model):
             args=(str(battle.id),),
         )
         db_game_1_2 = DBGame.objects.create(
+            battle=battle,
             llm=warrior_arena_1.arena.llm,
             warrior_1=warrior_1,
             warrior_2=warrior_2,
@@ -217,6 +218,7 @@ class Battle(models.Model):
             processed_goal=resolve_1_2_goal,
         )
         db_game_2_1 = DBGame.objects.create(
+            battle=battle,
             llm=warrior_arena_1.arena.llm,
             warrior_1=warrior_2,
             warrior_2=warrior_1,
@@ -256,6 +258,15 @@ class DBGame(GoalRelatedMixin, models.Model):
         default=uuid.uuid4,
         editable=False,
     )
+    # Null only on legacy rows awaiting the backfill_game_battles command;
+    # goes not-null once the backfill has run
+    # (docs/game-migration.md, step 1).
+    battle = models.ForeignKey(
+        to='Battle',
+        on_delete=models.CASCADE,
+        related_name='games',
+        null=True,
+    )
     llm = models.CharField(
         max_length=20,
         choices=LLM.choices,
@@ -264,6 +275,9 @@ class DBGame(GoalRelatedMixin, models.Model):
         db_index=True,
         default=timezone.now,
     )
+    # Warriors are in prompt order, unlike the battle's canonical order;
+    # comparing warrior_1_id with battle.warrior_1_id recovers the direction,
+    # so direction is derived, never stored (docs/game-migration.md).
     warrior_1 = models.ForeignKey(
         to=Warrior,
         on_delete=models.PROTECT,
@@ -304,6 +318,12 @@ class DBGame(GoalRelatedMixin, models.Model):
 
     class Meta:
         db_table = 'warriors_game'
+        constraints = [
+            models.UniqueConstraint(
+                fields=('battle', 'warrior_1'),
+                name='unique_battle_direction',
+            ),
+        ]
 
 
 @dataclass(frozen=True)

--- a/warriors/management/commands/backfill_game_battles.py
+++ b/warriors/management/commands/backfill_game_battles.py
@@ -1,0 +1,66 @@
+"""
+Link legacy DBGame rows to their Battle
+by the (llm, warrior pair, scheduled_at) match;
+docs/game-migration.md, step 1, owns why that triple is acceptable here
+and what follows once the final report shows zero unlinked rows.
+
+Runs in batches, each its own transaction,
+so it holds no long locks and can be interrupted and rerun;
+already-linked rows are never touched.
+The two directions are matched by separate equality-only updates:
+a single update with an OR over the swapped warrior pair
+defeats the planner (no hash join) and degrades to
+a per-row nested loop over the battles table.
+"""
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+from ...battles import DBGame
+
+
+MATCH_SQL = """
+    UPDATE warriors_game g
+    SET battle_id = b.id
+    FROM warriors_battle b
+    WHERE g.id = ANY(%(ids)s)
+      AND g.battle_id IS NULL
+      AND b.llm = g.llm
+      AND b.scheduled_at = g.scheduled_at
+      AND b.warrior_1_id = g.{first}
+      AND b.warrior_2_id = g.{second}
+"""
+
+
+class Command(BaseCommand):
+    help = 'Link legacy game rows to their battle'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--batch-size', type=int, default=10000)
+
+    def handle(self, *args, batch_size, **options):
+        last_id = None
+        scanned = 0
+        linked = 0
+        while True:
+            games = DBGame.objects.filter(battle=None).order_by('id')
+            if last_id is not None:
+                games = games.filter(id__gt=last_id)
+            ids = list(games.values_list('id', flat=True)[:batch_size])
+            if not ids:
+                break
+            last_id = ids[-1]
+            scanned += len(ids)
+            with transaction.atomic(), connection.cursor() as cursor:
+                cursor.execute(
+                    MATCH_SQL.format(first='warrior_1_id', second='warrior_2_id'),
+                    {'ids': ids},
+                )
+                linked += cursor.rowcount
+                cursor.execute(
+                    MATCH_SQL.format(first='warrior_2_id', second='warrior_1_id'),
+                    {'ids': ids},
+                )
+                linked += cursor.rowcount
+            self.stdout.write(f'scanned {scanned}, linked {linked}')
+        unlinked = DBGame.objects.filter(battle=None).count()
+        self.stdout.write(f'done: linked {linked}, {unlinked} left unlinked')

--- a/warriors/migrations/0058_dbgame_battle.py
+++ b/warriors/migrations/0058_dbgame_battle.py
@@ -1,0 +1,32 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('warriors', '0057_remove_battle_lcs_len_1_2_1_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dbgame',
+            name='battle',
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='games',
+                to='warriors.battle',
+            ),
+        ),
+        # Null battle rows are exempt from the constraint,
+        # so it guards the dual-write in Battle.create_from_warriors
+        # from day one while legacy rows await backfill_game_battles.
+        migrations.AddConstraint(
+            model_name='dbgame',
+            constraint=models.UniqueConstraint(
+                fields=('battle', 'warrior_1'),
+                name='unique_battle_direction',
+            ),
+        ),
+    ]

--- a/warriors/tests/factories.py
+++ b/warriors/tests/factories.py
@@ -77,6 +77,7 @@ def batch_create_battles(arena, warrior_arena, n):
 
         # Create corresponding DBGame objects
         DBGame.objects.create(
+            battle=battle,
             llm=arena.llm,
             warrior_1=battle_warrior_1,
             warrior_2=battle_warrior_2,
@@ -85,6 +86,7 @@ def batch_create_battles(arena, warrior_arena, n):
             resolved_at=battle.resolved_at_1_2,
         )
         DBGame.objects.create(
+            battle=battle,
             llm=arena.llm,
             warrior_1=battle_warrior_2,
             warrior_2=battle_warrior_1,

--- a/warriors/tests/test_backfill_game_battles.py
+++ b/warriors/tests/test_backfill_game_battles.py
@@ -1,0 +1,51 @@
+import pytest
+from django.core.management import call_command
+
+from ..battles import DBGame
+from .factories import BattleFactory, WarriorFactory
+
+
+@pytest.mark.django_db
+def test_backfill_links_both_directions():
+    warrior_a = WarriorFactory()
+    warrior_b = WarriorFactory()
+    warrior_1, warrior_2 = sorted([warrior_a, warrior_b], key=lambda w: w.id)
+    battle = BattleFactory(llm='openai-gpt', warrior_1=warrior_1, warrior_2=warrior_2)
+    game_1_2 = DBGame.objects.create(
+        battle=None,
+        llm=battle.llm,
+        warrior_1=warrior_1,
+        warrior_2=warrior_2,
+        scheduled_at=battle.scheduled_at,
+    )
+    game_2_1 = DBGame.objects.create(
+        battle=None,
+        llm=battle.llm,
+        warrior_1=warrior_2,
+        warrior_2=warrior_1,
+        scheduled_at=battle.scheduled_at,
+    )
+
+    call_command('backfill_game_battles', batch_size=1)
+
+    game_1_2.refresh_from_db()
+    game_2_1.refresh_from_db()
+    assert game_1_2.battle_id == battle.id
+    assert game_2_1.battle_id == battle.id
+
+
+@pytest.mark.django_db
+def test_backfill_leaves_unmatched_rows_null():
+    warrior_a = WarriorFactory()
+    warrior_b = WarriorFactory()
+    game = DBGame.objects.create(
+        battle=None,
+        llm='openai-gpt',
+        warrior_1=warrior_a,
+        warrior_2=warrior_b,
+    )
+
+    call_command('backfill_game_battles')
+
+    game.refresh_from_db()
+    assert game.battle_id is None

--- a/warriors/tests/test_e2e.py
+++ b/warriors/tests/test_e2e.py
@@ -69,6 +69,8 @@ def test_battle_from_warriors_e2e(monkeypatch, warrior_arena, other_warrior_aren
     # Verify DBGame objects were created
     db_game_1_2.refresh_from_db()
     db_game_2_1.refresh_from_db()
+    assert db_game_1_2.battle_id == battle.id
+    assert db_game_2_1.battle_id == battle.id
     assert db_game_1_2.warrior_1 == battle.warrior_1
     assert db_game_1_2.warrior_2 == battle.warrior_2
     assert db_game_2_1.warrior_1 == battle.warrior_2


### PR DESCRIPTION
Implements step 1 of the game migration (docs/game-migration.md):
add a nullable `battle` foreign key to `DBGame` and backfill historical rows.

## Changes

- **Migration 0058**: Add `battle` ForeignKey to `DBGame` (nullable, blank) and a `UniqueConstraint` on (battle, warrior_1) that exempts null rows. This guards the dual-write in `Battle.create_from_warriors` from day one while legacy rows await backfill.

- **New management command** `backfill_game_battles`: Links legacy `DBGame` rows to their `Battle` by matching on (llm, warriors, scheduled_at). Runs in batches to avoid holding table locks; each batch is its own transaction and can be interrupted and rerun. Handles both warrior orderings (1→2 and 2→1) with separate equality-only updates to avoid planner degradation.

- **Dual-write in `Battle.create_from_warriors`**: New `DBGame` rows now set `battle=battle` at creation time.

- **Test coverage**: Two tests verify the backfill links games in both directions and leaves unmatched rows null.

- **Updated factories and e2e test**: Set `battle` on `DBGame` creation; e2e test asserts the foreign key is populated.

The not-null enforcement and follow-up migrations are deferred until after production backfill confirms zero unlinked rows.

https://claude.ai/code/session_01Jdxy8py9rbRYPx8KdXteNq