### PR TITLE
Make DBGame rows mandatory in resolve_battle

### DIFF
--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -62,37 +62,29 @@ after the last reader leaves.
 While a dual-write holds,
 rolling back a reader flip is a code revert with no data repair.
 
-### 1. Verify the shadow copy and make it mandatory
+Every step rests on one invariant:
+a battle direction always has its game row,
+faithful to the battle's directional columns
+while the battle is the authoritative writer.
+`Battle.create_from_warriors` writes battle and both games
+in one transaction,
+`resolve_battle` loads the row unconditionally
+by the unique (battle, warrior_1),
+and the test factory creates both rows with every battle.
 
-The `verify_games` management command walks every battle direction
-and compares all mirrored fields against the game row —
-the per-request assertions in `resolve_battle`, made exhaustive.
-It ships and runs on its own,
-ahead of anything that depends on a complete table.
-
-Auditing and repairing stay apart.
-`verify_games` writes nothing:
+Checking that invariant and repairing it stay apart.
+The `verify_games` audit writes nothing:
 it counts each kind of difference with one example row,
 because a single bad historical backfill leaves a finding
 on every battle in the table
 and the mass ones must not bury the single odd one.
-Each repair is then its own command, named for what it repairs,
+Each repair is its own command, named for what it repairs,
 deleted once a production run leaves nothing to do —
 `backfill_game_input_sha256` covers the one cause known so far,
 `backfill_sha.py` having written the battle's sha and not the game's.
-A finding nothing explains is a bug to chase, not data to copy over,
-and the directional columns cannot be dropped while any remain.
+A finding nothing explains is a bug to chase, not data to copy over.
 
-With the table verified, `resolve_battle`
-stops tolerating a missing game row:
-the `DBGame.DoesNotExist` branch goes away,
-and the lookup keys on the unique (battle, warrior_1)
-rather than on `processed_goal`,
-which backfilled rows do not have.
-The test factory takes on the same invariant,
-creating both game rows with every battle.
-
-### 2. Invert write authority
+### 1. Invert write authority
 
 `resolve_battle` and `_run_llm` currently treat
 the `Game` facade over `Battle` as primary
@@ -106,7 +98,7 @@ only which object is authoritative and which is the copy.
 After this step the directional columns are write-only,
 the same state the `lcs_len_*` columns were in before removal.
 
-### 3. Re-key GameScore
+### 2. Re-key GameScore
 
 Add a nullable `game` foreign key to `GameScore`,
 dual-written in `get_or_create_game_score` (`warriors/score.py`);
@@ -118,7 +110,7 @@ instead of constructing the battle facade.
 `direction` and `battle` drop from `GameScore`
 once nothing selects by them.
 
-### 4. Cut the remaining readers over
+### 3. Cut the remaining readers over
 
 In order of blast radius:
 
@@ -142,23 +134,27 @@ In order of blast radius:
   cooldown, opponent exclusion, and `battle_count`
   are pair-level and stay on `Battle`.
 
-### 5. Drop the directional columns
+### 4. Drop the directional columns
+
+Not while `verify_games` still reports a finding:
+after this the game row is the only copy,
+so anything it lacks is lost here.
 
 Delete the paired columns from `Battle`
 (`input_sha256_*`, `text_unit_*`, `finish_reason_*`,
 `llm_version_*`, `resolved_at_*`, `attempts_*`),
-the step-2 mirror writes,
+the step-1 mirror writes,
 and the facade machinery that mapped suffixed names.
-The `verify_games` command goes with them —
+The command goes with the columns —
 it compares game rows against columns that no longer exist,
 and `mirrored_game_fields` has nothing left to map.
 Same shape as the `lcs_len_*` removal.
 The dead `rating_transferred_at` column
 (tracked in `TODO.md`) rides along.
 
-### 6. Rename
+### 5. Rename
 
-With the in-memory `Game` facade deleted in step 5,
+With the in-memory `Game` facade deleted in step 4,
 the name is free:
 `DBGame` becomes `Game`.
 The table is already `warriors_game`,
@@ -174,7 +170,7 @@ This plan is one of its independently-shippable tracks
 and orders only its own steps;
 dropping `Battle.arena` can land any time,
 and the ranking-registry work is untouched by it —
-rating reads change *representation* here (step 4),
+rating reads change *representation* here (step 3),
 not which signal feeds them.
 
 ## Open decisions

--- a/warriors/llms/anthropic_tests.py
+++ b/warriors/llms/anthropic_tests.py
@@ -3,7 +3,6 @@ from unittest import mock
 import anthropic
 import pytest
 
-from ..battles import DBGame
 from ..models import LLM
 from ..tasks import resolve_battle
 
@@ -40,9 +39,8 @@ def test_resolve_battle(battle, anthropic_messages_create_mock):
     assert battle.llm_version_1_2 == 'claude-3-haiku-20240307'
     assert battle.finish_reason_1_2 == 'end_turn'
 
-    # DBGame is not created when goal is None (in unit tests)
-    # In production, DBGame would be created by Battle.create_from_warriors
-    assert DBGame.objects.filter(
-        warrior_1=battle.warrior_1,
-        warrior_2=battle.warrior_2,
-    ).count() == 0
+    # the game row mirrors what the battle's directional columns got
+    db_game = battle.games.get(warrior_1=battle.warrior_1)
+    assert db_game.text_unit_id == battle.text_unit_1_2_id
+    assert db_game.llm_version == battle.llm_version_1_2
+    assert db_game.finish_reason == battle.finish_reason_1_2

--- a/warriors/tasks.py
+++ b/warriors/tasks.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.utils import timezone
 from django_goals.models import AllDone, RetryMeLater, schedule
 
-from .battles import LLM, MATCHMAKING_COOLDOWN, Battle, DBGame, Game
+from .battles import LLM, MATCHMAKING_COOLDOWN, Battle, Game
 from .llms import anthropic
 from .llms.exceptions import TransientLLMError
 from .llms.google import resolve_battle_google
@@ -106,25 +106,26 @@ def resolve_battle_2_1(goal, battle_id):
     return resolve_battle(goal, battle_id, '2_1')
 
 
-def resolve_battle(goal, battle_id, direction, _game=None):
+def resolve_battle(goal, battle_id, direction):
     now = timezone.now()
     battle = Battle.objects.filter(id=battle_id).select_related(
         'warrior_1',
         'warrior_2',
     ).get()
     battle_view = Game(battle, direction)
-    try:
-        db_game = DBGame.objects.get(processed_goal=goal)
-    except DBGame.DoesNotExist:
-        db_game = None
-    if db_game is not None:
-        assert db_game.llm == battle.llm
-        assert db_game.warrior_1_id == battle_view.warrior_1_id
-        assert db_game.warrior_2_id == battle_view.warrior_2_id
-        assert db_game.scheduled_at == battle.scheduled_at
+    # Both rows exist for every battle: Battle.create_from_warriors writes
+    # them in its transaction, and the verify_games audit reports any
+    # battle that lacks one. The lookup keys on the unique
+    # (battle, warrior_1) — the direction key of the target schema.
+    # processed_goal cannot key it: backfilled rows have none, and goal
+    # collection clears the rest (SET_NULL).
+    db_game = battle.games.get(warrior_1_id=battle_view.warrior_1_id)
+    assert db_game.llm == battle.llm
+    assert db_game.warrior_2_id == battle_view.warrior_2_id
+    assert db_game.scheduled_at == battle.scheduled_at
 
     if battle_view.resolved_at is None:
-        r = _run_llm(battle_view, now, db_game=db_game)
+        r = _run_llm(battle_view, now, db_game)
         if isinstance(r, RetryMeLater):
             return r
         else:
@@ -147,7 +148,7 @@ def resolve_battle(goal, battle_id, direction, _game=None):
     return AllDone()
 
 
-def _run_llm(battle_view, now, db_game=None):
+def _run_llm(battle_view, now, db_game):
     resolve_battle_function = {
         LLM.OPENAI_GPT: resolve_battle_openai,
         LLM.CLAUDE_3_HAIKU: anthropic.resolve_battle,
@@ -171,9 +172,8 @@ def _run_llm(battle_view, now, db_game=None):
         battle_view.save(update_fields=['attempts'])
 
         # Update corresponding Game object
-        if db_game is not None:
-            db_game.attempts = battle_view.attempts
-            db_game.save(update_fields=['attempts'])
+        db_game.attempts = battle_view.attempts
+        db_game.save(update_fields=['attempts'])
 
         if attempts < 6:
             # try again in some time
@@ -208,19 +208,18 @@ def _run_llm(battle_view, now, db_game=None):
     ])
 
     # Update corresponding Game object
-    if db_game is not None:
-        db_game.input_sha256 = battle_view.input_sha256
-        db_game.text_unit = battle_view.text_unit
-        db_game.finish_reason = battle_view.finish_reason
-        db_game.llm_version = battle_view.llm_version
-        db_game.resolved_at = now
-        db_game.save(update_fields=[
-            'input_sha256',
-            'text_unit',
-            'finish_reason',
-            'llm_version',
-            'resolved_at',
-        ])
+    db_game.input_sha256 = battle_view.input_sha256
+    db_game.text_unit = battle_view.text_unit
+    db_game.finish_reason = battle_view.finish_reason
+    db_game.llm_version = battle_view.llm_version
+    db_game.resolved_at = now
+    db_game.save(update_fields=[
+        'input_sha256',
+        'text_unit',
+        'finish_reason',
+        'llm_version',
+        'resolved_at',
+    ])
 
 
 def transfer_rating(goal, battle_id):

--- a/warriors/tests/factories.py
+++ b/warriors/tests/factories.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from users.tests.factories import UserFactory
 
-from ..battles import Battle, DBGame
+from ..battles import Battle, DBGame, mirrored_game_fields
 from ..models import LLM, Arena, WarriorArena, WarriorUserPermission
 from ..score import GameScore
 from ..text_unit import TextUnit
@@ -50,9 +50,25 @@ class WarriorUserPermissionFactory(factory.django.DjangoModelFactory):
 class BattleFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Battle
+        skip_postgeneration_save = True
 
     warrior_1 = factory.SubFactory(WarriorFactory)
     warrior_2 = factory.SubFactory(WarriorFactory)
+
+    @factory.post_generation
+    def games(battle, create, extracted, **kwargs):
+        """
+        Hold the invariant `resolve_battle` relies on:
+        a battle comes with its two game rows,
+        mirroring whichever directional fields the caller set.
+        """
+        if not create:
+            return
+        for direction in ('1_2', '2_1'):
+            DBGame.objects.create(
+                battle=battle,
+                **mirrored_game_fields(battle, direction),
+            )
 
 
 def batch_create_battles(arena, warrior_arena, n):
@@ -74,27 +90,6 @@ def batch_create_battles(arena, warrior_arena, n):
             resolved_at_2_1=timezone.now(),
             text_unit_2_1=TextUnitFactory(),
         )
-
-        # Create corresponding DBGame objects
-        DBGame.objects.create(
-            battle=battle,
-            llm=arena.llm,
-            warrior_1=battle_warrior_1,
-            warrior_2=battle_warrior_2,
-            scheduled_at=battle.scheduled_at,
-            text_unit=battle.text_unit_1_2,
-            resolved_at=battle.resolved_at_1_2,
-        )
-        DBGame.objects.create(
-            battle=battle,
-            llm=arena.llm,
-            warrior_1=battle_warrior_2,
-            warrior_2=battle_warrior_1,
-            scheduled_at=battle.scheduled_at,
-            text_unit=battle.text_unit_2_1,
-            resolved_at=battle.resolved_at_2_1,
-        )
-
         battles.append(battle)
     return battles
 

--- a/warriors/tests/test_tasks.py
+++ b/warriors/tests/test_tasks.py
@@ -11,7 +11,6 @@ from openai.types.chat.chat_completion import (
 )
 from openai.types.completion_usage import CompletionUsage
 
-from ..battles import DBGame
 from ..tasks import (
     do_moderation, openai_client, resolve_battle, schedule_battle_top_arena,
     transfer_rating,
@@ -145,12 +144,13 @@ def test_resolve_battle(arena, battle, monkeypatch):
     assert battle.resolved_at_2_1 is not None
     assert battle.llm_version_2_1 == 'gpt-3.5/1234'
 
-    # DBGame is not created when goal is None (in unit tests)
-    # In production, DBGame would be created by Battle.create_from_warriors
-    assert DBGame.objects.filter(
-        warrior_1=battle.warrior_2,
-        warrior_2=battle.warrior_1,
-    ).count() == 0
+    # the game row mirrors what the battle's directional columns got
+    db_game = battle.games.get(warrior_1=battle.warrior_2)
+    assert bytes(db_game.input_sha256) == bytes(battle.input_sha256_2_1)
+    assert db_game.text_unit_id == battle.text_unit_2_1_id
+    assert db_game.finish_reason == battle.finish_reason_2_1
+    assert db_game.resolved_at == battle.resolved_at_2_1
+    assert db_game.llm_version == battle.llm_version_2_1
 
 
 @pytest.mark.django_db

--- a/warriors/tests/test_verify_games.py
+++ b/warriors/tests/test_verify_games.py
@@ -3,7 +3,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.utils import timezone
 
-from ..battles import LLM, DBGame, mirrored_game_fields
+from ..battles import LLM
 from .factories import BattleFactory, TextUnitFactory, WarriorFactory
 
 
@@ -19,7 +19,7 @@ def create_mirrored_battle():
         WarriorFactory.create_batch(2),
         key=lambda warrior: warrior.id,
     )
-    battle = BattleFactory(
+    return BattleFactory(
         llm=LLM.OPENAI_GPT,
         warrior_1=warrior_1,
         warrior_2=warrior_2,
@@ -34,12 +34,6 @@ def create_mirrored_battle():
         llm_version_2_1='gpt-3.5/1234',
         input_sha256_2_1=b'\x02' * 32,
     )
-    for direction in ('1_2', '2_1'):
-        DBGame.objects.create(
-            battle=battle,
-            **mirrored_game_fields(battle, direction),
-        )
-    return battle
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Enforce the invariant that every battle direction has a corresponding `DBGame` row by removing optional handling and keying lookups on the unique `(battle, warrior_1)` constraint.

## Summary

This change completes the migration toward making `Game` (currently `DBGame`) the authoritative schema for battle resolution results.
The `resolve_battle` and `_run_llm` functions now require a `DBGame` row to exist for every battle direction, eliminating the `DoesNotExist` exception handling and optional `db_game` parameter.

## Key changes

- **Remove optional `DBGame` handling**: `resolve_battle` and `_run_llm` no longer accept `_game=None` or tolerate missing rows; they load the row unconditionally via `battle.games.get(warrior_1_id=...)` keyed on the unique constraint.
- **Simplify conditional logic**: Remove `if db_game is not None:` guards around all `DBGame` updates in `_run_llm`, since the row is now guaranteed to exist.
- **Update test factories**: `BattleFactory` now creates both game rows via a `@factory.post_generation` hook using `mirrored_game_fields`, matching the invariant that `Battle.create_from_warriors` enforces in production.
- **Update test assertions**: Replace checks for missing `DBGame` rows with assertions that verify the game row mirrors the battle's directional columns.
- **Simplify migration docs**: Consolidate the verification and mandatory-row steps into a single invariant statement, renumbering subsequent steps.

## Implementation details

The lookup key changed from `processed_goal` (which cannot work for backfilled rows and is cleared by goal collection) to `(battle, warrior_1)`, the unique constraint that both `Battle.create_from_warriors` and the `verify_games` command use.
This aligns the code with the actual schema and removes a source of subtle bugs where a missing row would silently pass through.

https://claude.ai/code/session_0114xNrUyk8Tuzz9uuKCRvUE