### PR TITLE
Document data repair patterns and game migration decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,31 @@ its header has the convention.
 Game-design ideas and philosophical observations are not debt:
 they go to `CONCEPT.md` or `docs/`, next to their rationale.
 
+## One-off data repairs are commands, not scripts
+
+A migration or a bad backfill leaves rows to fix.
+The fix belongs in `warriors/management/commands/`
+as a named command with a test,
+reachable from `manage.py` and reviewed like any other code.
+The scripts at the repo root show what the alternative costs:
+untested, invisible to `manage.py`,
+and no record of whether they were ever run
+(`TODO.md` tracks them).
+Name the command after what it repairs,
+say in its docstring what made the rows wrong,
+and log the condition for deleting it in `TODO.md`:
+a repair is finished when its rows are gone,
+and the ones that outlive that condition are the ones that rot.
+
+Auditing and repairing are separate commands.
+An audit that writes is one you hesitate to run,
+and a repair that decides for itself which differences are benign
+hides the bug you were looking for —
+so an audit reports, counting each kind of finding
+rather than listing every row,
+and a repair fixes one named cause.
+`verify_games` and `backfill_game_input_sha256` are the pair to copy.
+
 ## Prose uses semantic line breaks
 
 Write natural-language text —

--- a/TODO.md
+++ b/TODO.md
@@ -89,14 +89,54 @@ Next move: drop the field, the comment, and the mapping entry,
 same shape as the `lcs_len_*` column removal;
 implies a schema migration but no behavior change.
 
+Seven game rows hold none of the result their battle recorded:
+`text_unit`, `finish_reason`, `llm_version` and `resolved_at` are blank
+on a direction the battle has resolved
+(five battles, all scheduled 2026-02-08; `verify_games` reports them).
+Blank is what the old resolver left
+when it could not find the game row by `processed_goal`:
+it wrote the battle and skipped the mirror.
+Why the lookup missed is not established;
+the rows carry their goals and match their battle
+on `llm` and `scheduled_at`, so the row existed when the goal ran.
+Next move: a `backfill_game_resolution` command,
+one `UPDATE ... FROM` per direction guarded by
+`g.resolved_at IS NULL AND b.resolved_at_<dir> IS NOT NULL`
+so it cannot touch a direction still in flight,
+deleted after its run.
+The directional columns cannot be dropped before that:
+the battle holds the only copy of those seven results.
+A recurrence now surfaces as a `DBGame.DoesNotExist` goal failure,
+which is what to look for if the count grows.
+
 `warriors/management/commands/backfill_game_input_sha256.py`
-is a one-time repair, kept only until it has nothing left to do:
-it copies `Battle.input_sha256_*` onto the game rows that lack it,
-the gap `backfill_sha.py` leaves behind.
-Next move: delete it once a production run reports nothing still blank
-and `verify_games` no longer reports `blank input_sha256`,
-the same way `backfill_game_battles` went
-after the battle links were in place.
+is a one-time repair with 34 rows left to its name:
+those game rows are blank because their battle has no sha either,
+so it has nothing to copy,
+and `verify_games` cannot see them —
+blank on both sides compares equal.
+A direction still in flight is among them and needs nothing:
+resolution writes both sides.
+Next move: for the rest, either recompute the missing battle shas
+(the root-level `backfill_sha.py` derives them from the warrior bodies)
+and run the command once more,
+or settle that the 34 stay blank —
+either way the command then goes,
+the way `backfill_game_battles` went
+once the battle links were in place.
+
+`verify_games` skips a direction the battle has not resolved,
+which leaves `llm` and `scheduled_at` unchecked
+on exactly the rows `resolve_battle`'s asserts act on:
+those two are set when the pair is created, not at resolution,
+so an unresolved direction can hold a drifted copy
+and the audit will not say so.
+Next move: split the comparison —
+the creation-time fields (`llm`, `scheduled_at`, the warrior pair)
+on every direction,
+the resolution fields only once the battle has resolved it.
+The skip exists because `attempts` climbs while a direction retries,
+and that is a resolution field.
 
 Five one-off scripts sit at the repo root —
 `backfill_sha.py`, `create_game_score.py`, `set_game_score.py`,
@@ -106,7 +146,7 @@ untested and unreachable from `manage.py`.
 They rot invisibly:
 `backfill_sha.py` cites a `verify_ordering.py` that is not in the tree,
 and it writes `Battle.input_sha256_*` without the matching game rows —
-the blanks the `verify_games` command exists to fill.
+the blanks `backfill_game_input_sha256` exists to fill.
 Next move: for each, decide between
 a management command next to `warriors/management/commands/verify_games.py`
 if the operation is still worth running,

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -182,3 +182,11 @@ not which signal feeds them.
   in `GameScore` though it is symmetric per (battle, algorithm);
   correct home is a per-battle score object,
   which is not worth introducing during this migration.
+- **Whether `Game` keeps `input_sha256`.**
+  The resolver writes it and nothing reads it,
+  and it is derivable from the two warrior bodies —
+  `backfill_sha.py` recomputes it that way.
+  If it stays, the blanks tracked in `TODO.md`
+  have to be filled before the columns drop;
+  if it goes, they stop mattering
+  and the drop is the moment to remove it.


### PR DESCRIPTION
Update project documentation to capture patterns for handling data repairs and decisions about the game migration.

## Summary

This change documents two key areas:
1. Patterns for implementing one-off data repairs as management commands rather than scripts
2. Current state and open questions about data quality issues discovered during the game migration

## Changes

- **AGENTS.md**: Add new section "One-off data repairs are commands, not scripts" establishing the convention that repairs belong in `warriors/management/commands/` with tests and deletion criteria, not as root-level scripts. Uses `verify_games` and `backfill_game_input_sha256` as the exemplar pair.

- **TODO.md**: 
  - Document seven game rows with blank resolution fields (`text_unit`, `finish_reason`, `llm_version`, `resolved_at`) where the old resolver failed to find game rows by `processed_goal`. Include the lookup failure analysis and planned `backfill_game_resolution` command with its safety guards.
  - Update `backfill_game_input_sha256` section to reflect current state: 34 rows remain blank because their battles lack shas too, and `verify_games` cannot detect this. Clarify next steps: either recompute missing battle shas or accept the blanks.
  - Add new section on `verify_games` audit gap: unresolved directions skip validation of `llm` and `scheduled_at`, which can drift undetected. Propose splitting the audit into creation-time and resolution-time field checks.
  - Fix reference from "the blanks the `verify_games` command exists to fill" to "the blanks `backfill_game_input_sha256` exists to fill" for accuracy.

- **docs/game-migration.md**: Add decision point about whether `Game` keeps `input_sha256` field. Document that it's write-only (resolver writes, nothing reads) and derivable from warrior bodies, with implications for blank-filling work before column removal.

## Implementation notes

All changes are documentation only. The sections follow semantic line breaks convention and establish clear ownership: code owns "what is implemented", docs own "why decisions were made and what work remains".

https://claude.ai/code/session_0114xNrUyk8Tuzz9uuKCRvUE