### PR TITLE
Add backfill_game_resolution command to repair missing game results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,11 @@ EOF
 cd /home/user/prompt-wars
 pip install poetry
 poetry install
+
+# Build the staticfiles manifest — ManifestStaticFilesStorage resolves
+# {% static %} through it, so any test that renders a page (the admin
+# tests) fails with "Missing staticfiles manifest entry" without this.
+poetry run python manage.py collectstatic --noinput
 ```
 
 ### Running tests
@@ -175,6 +180,10 @@ poetry install
 ```bash
 cd /home/user/prompt-wars
 poetry run python -m pytest embedding_explorer/tests.py -v
+
+# Tests marked real_world call live LLM and embedding endpoints and fail
+# on the dummy keys above; deselect them to read the suite's real state.
+poetry run python -m pytest warriors/ -m "not real_world"
 ```
 
 ### Linting

--- a/TODO.md
+++ b/TODO.md
@@ -99,11 +99,10 @@ it wrote the battle and skipped the mirror.
 Why the lookup missed is not established;
 the rows carry their goals and match their battle
 on `llm` and `scheduled_at`, so the row existed when the goal ran.
-Next move: a `backfill_game_resolution` command,
-one `UPDATE ... FROM` per direction guarded by
-`g.resolved_at IS NULL AND b.resolved_at_<dir> IS NOT NULL`
-so it cannot touch a direction still in flight,
-deleted after its run.
+`backfill_game_resolution` fills them;
+next move is to run it in production
+and delete the command once `verify_games` reports nothing,
+the way `backfill_game_battles` went.
 The directional columns cannot be dropped before that:
 the battle holds the only copy of those seven results.
 A recurrence now surfaces as a `DBGame.DoesNotExist` goal failure,

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -79,9 +79,11 @@ because a single bad historical backfill leaves a finding
 on every battle in the table
 and the mass ones must not bury the single odd one.
 Each repair is its own command, named for what it repairs,
-deleted once a production run leaves nothing to do —
-`backfill_game_input_sha256` covers the one cause known so far,
-`backfill_sha.py` having written the battle's sha and not the game's.
+deleted once a production run leaves nothing to do:
+`backfill_game_input_sha256` for `backfill_sha.py`
+having written the battle's sha and not the game's,
+`backfill_game_resolution` for the old resolver
+having written the battle's result and skipped the mirror.
 A finding nothing explains is a bug to chase, not data to copy over.
 
 ### 1. Invert write authority

--- a/warriors/management/commands/backfill_game_resolution.py
+++ b/warriors/management/commands/backfill_game_resolution.py
@@ -1,0 +1,88 @@
+"""
+Copy a battle direction's result onto the game row that never got it.
+
+Some game rows hold none of the result their battle recorded:
+blank `text_unit`, `finish_reason`, `llm_version` and `resolved_at`
+on a direction the battle has resolved (`TODO.md` carries the count).
+Blank is what the old resolver left
+when it could not find the game row by `processed_goal` —
+it wrote the battle and skipped the mirror.
+The battle holds the only copy of those results,
+so they have to move before the directional columns drop
+(`docs/game-migration.md`, step 4).
+`attempts` rides along, though nothing reports it blank:
+the lookup can start failing partway through the retries,
+which leaves the game's count behind the battle's final one.
+
+`resolved_at` is what makes a direction safe to touch:
+null on the game and set on the battle
+means a result that is final and a mirror that never ran.
+A direction still in flight is left alone —
+its `attempts` is being written as we read,
+and resolution mirrors the whole result when it lands.
+The id scan offers only unresolved games, and the statement checks again —
+not redundant: a direction that resolves between the two is skipped.
+
+Batched, and one statement per direction,
+like `backfill_game_input_sha256` and for the same reasons.
+Delete this command once a production run leaves nothing to fill,
+the way `backfill_game_battles` went once the battle links were in place.
+"""
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+from ...battles import DBGame
+
+
+FILL_SQL = """
+    UPDATE warriors_game g
+    SET text_unit_id = b.text_unit_{direction}_id,
+        finish_reason = b.finish_reason_{direction},
+        llm_version = b.llm_version_{direction},
+        attempts = b.attempts_{direction},
+        resolved_at = b.resolved_at_{direction}
+    FROM warriors_battle b
+    WHERE g.id = ANY(%(ids)s)
+      AND g.battle_id = b.id
+      AND g.warrior_1_id = b.{first}
+      AND g.resolved_at IS NULL
+      AND b.resolved_at_{direction} IS NOT NULL
+"""
+DIRECTIONS = (
+    ('1_2', 'warrior_1_id'),
+    ('2_1', 'warrior_2_id'),
+)
+
+
+class Command(BaseCommand):
+    help = 'Fill game rows missing the result their battle has'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--batch-size', type=int, default=10000)
+
+    def handle(self, *args, batch_size, **options):
+        scanned = 0
+        filled = 0
+        last_id = None
+        while True:
+            # every unresolved game is a candidate, most of them in flight;
+            # the guard sorts them out inside the statement
+            games = DBGame.objects.filter(resolved_at=None).order_by('id')
+            if last_id is not None:
+                games = games.filter(id__gt=last_id)
+            ids = list(games.values_list('id', flat=True)[:batch_size])
+            if not ids:
+                break
+            last_id = ids[-1]
+            scanned += len(ids)
+            with transaction.atomic(), connection.cursor() as cursor:
+                for direction, first in DIRECTIONS:
+                    cursor.execute(
+                        FILL_SQL.format(direction=direction, first=first),
+                        {'ids': ids},
+                    )
+                    filled += cursor.rowcount
+            self.stdout.write(f'scanned {scanned}, filled {filled}')
+        # unresolved rows are left on purpose, so counting them says nothing
+        # about whether this is finished — verify_games answers that
+        self.stdout.write(f'done: filled {filled}')

--- a/warriors/management/commands/verify_games.py
+++ b/warriors/management/commands/verify_games.py
@@ -1,7 +1,8 @@
 """
 Audit every battle direction against its game row.
 Read-only: it reports, and repairing is a separate deliberate act
-(`backfill_game_input_sha256` is the one such repair the tree needs).
+(`backfill_game_input_sha256` and `backfill_game_resolution`
+are the repairs the tree needs).
 
 This checks the invariant every step of docs/game-migration.md rests on:
 a battle direction always has its game row,

--- a/warriors/tests/test_backfill_game_resolution.py
+++ b/warriors/tests/test_backfill_game_resolution.py
@@ -1,0 +1,75 @@
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from .test_verify_games import create_mirrored_battle
+
+
+def blank_the_mirror(battle):
+    """The state the old resolver left when it skipped the mirror."""
+    battle.games.all().update(
+        text_unit=None,
+        finish_reason='',
+        llm_version='',
+        resolved_at=None,
+    )
+
+
+@pytest.mark.django_db
+def test_fills_each_direction_from_its_own_columns():
+    battle = create_mirrored_battle()
+    blank_the_mirror(battle)
+
+    call_command('backfill_game_resolution', batch_size=1)
+
+    # the swapped warrior pair is the one thing the two statements can
+    # get wrong; which fields they carry is the audit's business below
+    game_1_2 = battle.games.get(warrior_1=battle.warrior_1)
+    game_2_1 = battle.games.get(warrior_1=battle.warrior_2)
+    assert game_1_2.text_unit_id == battle.text_unit_1_2_id
+    assert game_2_1.text_unit_id == battle.text_unit_2_1_id
+
+
+@pytest.mark.django_db
+def test_leaves_nothing_for_the_audit():
+    battle = create_mirrored_battle()
+    blank_the_mirror(battle)
+    # the blanks are what the audit reports, and what blocks the column drop
+    with pytest.raises(CommandError):
+        call_command('verify_games')
+
+    call_command('backfill_game_resolution')
+
+    call_command('verify_games')
+
+
+@pytest.mark.django_db
+def test_leaves_an_unresolved_direction_alone():
+    battle = create_mirrored_battle()
+    blank_the_mirror(battle)
+    battle.resolved_at_1_2 = None
+    battle.attempts_1_2 = 3
+    battle.save(update_fields=['resolved_at_1_2', 'attempts_1_2'])
+
+    call_command('backfill_game_resolution')
+
+    # a direction still retrying has its attempts written under us;
+    # resolution mirrors the whole result when it lands
+    game_1_2 = battle.games.get(warrior_1=battle.warrior_1)
+    assert game_1_2.resolved_at is None
+    assert game_1_2.attempts == 0
+
+
+@pytest.mark.django_db
+def test_leaves_a_resolved_game_alone():
+    battle = create_mirrored_battle()
+    game_1_2 = battle.games.get(warrior_1=battle.warrior_1)
+    game_1_2.finish_reason = 'character_limit'
+    game_1_2.save(update_fields=['finish_reason'])
+
+    call_command('backfill_game_resolution')
+
+    # a resolved row disagreeing with its battle is a bug for verify_games
+    # to report, not data for a repair to paper over
+    game_1_2.refresh_from_db()
+    assert game_1_2.finish_reason == 'character_limit'


### PR DESCRIPTION
Adds a management command to fill game rows that are missing result data (text_unit, finish_reason, llm_version, attempts, resolved_at) that their corresponding battle rows have already recorded.

## Summary

The old resolver sometimes failed to find game rows by `processed_goal` and wrote the battle result without mirroring it to the game. This command copies those results from the battle to the game before the directional columns are dropped in the migration.

## Key changes

- **New command `backfill_game_resolution`**: Fills missing game results from battle data using set-based, batched UPDATE statements guarded by `resolved_at IS NULL` on the game and `resolved_at IS NOT NULL` on the battle, ensuring only final results are copied and in-flight directions are skipped.
- **Test coverage**: Comprehensive tests verify both directions are filled correctly, unresolved directions are left alone, already-resolved games are not overwritten, and the audit passes after backfill.
- **Documentation updates**: Updated `TODO.md` and `docs/game-migration.md` to reflect the new repair command and its deletion criteria (once production run leaves nothing to fill), and updated `verify_games.py` docstring to list both repair commands.

## Implementation details

The command processes unresolved games in batches, executing separate UPDATE statements for each direction (1→2 and 2→1) within atomic transactions. The SQL guard ensures a direction is only touched if its game row has no result (`resolved_at IS NULL`) while its battle direction has resolved (`resolved_at IS NOT NULL`), preventing overwrites and skipping in-flight directions whose attempts are still being written.

https://claude.ai/code/session_01SDCiZijweP91KXCuaGdxLh