### PR TITLE
Settle `input_sha256` as consistency anchor; update migration docs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -89,21 +89,22 @@ Next move: drop the field, the comment, and the mapping entry,
 same shape as the `lcs_len_*` column removal;
 implies a schema migration but no behavior change.
 
-`warriors/management/commands/backfill_game_input_sha256.py`
-is a one-time repair with 34 rows left to its name:
-those game rows are blank because their battle has no sha either,
-so it has nothing to copy,
+`Game.input_sha256` stays as a consistency anchor
+("Where the design lands" in `docs/game-migration.md`),
+which makes the 34 game rows with a blank sha worth filling.
+They are blank because their battle has no sha either,
+so `backfill_game_input_sha256` has nothing to copy,
 and `verify_games` cannot see them —
 blank on both sides compares equal.
-A direction still in flight is among them and needs nothing:
-resolution writes both sides.
-Next move: for the rest, either recompute the missing battle shas
-(the root-level `backfill_sha.py` derives them from the warrior bodies)
-and run the command once more,
-or settle that the 34 stay blank —
-either way the command then goes,
-the way `backfill_game_battles` went
-once the battle links were in place.
+The fill waits for step 4 to drop the battle columns:
+filling only the game side of a live mirror
+reads as a `conflicting input_sha256` finding.
+Next move: once the columns are gone,
+a repair command that recomputes the sha from the warrior bodies
+(the way the root-level `backfill_sha.py` derives it)
+onto blank game rows.
+`backfill_game_input_sha256` goes at step 4
+with the columns it copies from.
 
 `verify_games` skips a direction the battle has not resolved,
 which leaves `llm` and `scheduled_at` unchecked
@@ -132,3 +133,7 @@ a management command next to `warriors/management/commands/verify_games.py`
 if the operation is still worth running,
 and deletion if it was a one-time fix —
 git keeps whichever ones get deleted.
+For `backfill_sha.py` the decision is settled:
+its recompute-from-bodies logic moves into
+the game-row sha repair command (see the `input_sha256` entry),
+and the script goes.

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -51,6 +51,26 @@ game-level processing reads the game's.
 Collapsing the duplication is possible after the dust settles
 but is not part of this migration.
 
+**`Game` keeps `input_sha256`.**
+Nothing reads it in production;
+it stays as a consistency anchor:
+a future audit can recompute the sha from the warrior bodies
+and compare,
+catching a drifted body
+or a resolution recorded against different inputs.
+The rejected alternative — dropping it as derivable —
+misses that derivability is what makes the check possible:
+a value that is only ever recomputed
+can never disagree with anything.
+The battle's directional pair carries no extra information
+and drops in step 4 with the other paired columns.
+The blank game rows (tracked in `TODO.md`)
+become worth filling by that same recomputation —
+but only after step 4:
+filling one side of a live mirror
+reads as a `verify_games` finding,
+and filling both sides writes columns that are about to drop.
+
 ## Steps
 
 Each step ships independently
@@ -93,6 +113,10 @@ and the battle's directional columns become the mirror.
 The facade's attribute names already match the game row's fields,
 so the resolver body barely changes —
 only which object is authoritative and which is the copy.
+The invariant and the `verify_games` audit survive
+with their direction flipped:
+equality is symmetric, so the comparison is unchanged,
+and only the docstrings' framing of who mirrors whom moves.
 After this step the directional columns are write-only,
 the same state the `lcs_len_*` columns were in before removal.
 
@@ -119,6 +143,11 @@ In order of blast radius:
   and their (game, algorithm) scores,
   instead of the directional columns and direction-keyed scores.
   The score-averaging semantics are unchanged.
+  This includes `BattleQuerySet.resolved()`,
+  which `update_rating` filters by:
+  it reads `resolved_at_1_2`/`_2_1` directly
+  and must come to mean
+  "both game rows have `resolved_at` set".
 - **Views and templates**:
   `BattleDetailView`, `RecentBattlesView`,
   and the warrior-detail battle list keep their battle-level shape,
@@ -180,11 +209,3 @@ not which signal feeds them.
   in `GameScore` though it is symmetric per (battle, algorithm);
   correct home is a per-battle score object,
   which is not worth introducing during this migration.
-- **Whether `Game` keeps `input_sha256`.**
-  The resolver writes it and nothing reads it,
-  and it is derivable from the two warrior bodies —
-  `backfill_sha.py` recomputes it that way.
-  If it stays, the blanks tracked in `TODO.md`
-  have to be filled before the columns drop;
-  if it goes, they stop mattering
-  and the drop is the moment to remove it.


### PR DESCRIPTION
Resolves the open question about whether `Game.input_sha256` should be kept or dropped.
The field stays as a consistency anchor for future audits,
enabling recomputation of the sha from warrior bodies to catch drifted data.

**Changes:**

- **`docs/game-migration.md`**: Document the decision to keep `input_sha256` and the rationale (derivability is what makes the check possible; a value only ever recomputed can never disagree with anything). Add detail on how the invariant and `verify_games` audit survive step 3 with direction flipped, and clarify that `BattleQuerySet.resolved()` must be updated to check both game rows have `resolved_at` set.

- **`TODO.md`**: Move the `input_sha256` decision from an open question to settled design. Reframe the 34 blank game rows as worth filling (after step 4 drops the battle columns) via a repair command that recomputes the sha from warrior bodies. Clarify that `backfill_game_input_sha256` goes at step 4 with the columns it copies from. Settle that `backfill_sha.py` is deleted; its recompute-from-bodies logic moves into the game-row sha repair command.

**Rationale:**

Keeping `input_sha256` enables a future audit to recompute it from the warrior bodies and compare against the stored value,
catching either a drifted body or a resolution recorded against different inputs.
The rejected alternative of dropping it as derivable misses that derivability is what makes the check possible:
a value that is only ever recomputed can never disagree with anything.

https://claude.ai/code/session_01171ai66JRv7yCZnnHgKNP4