### PR TITLE
Fix OpenAI token limit handling and add comprehensive tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,21 +106,34 @@ onto blank game rows.
 `backfill_game_input_sha256` goes at step 4
 with the columns it copies from.
 
-The token-limit branch in `resolve_battle_openai`
-(`warriors/llms/openai.py`) reads `response.text` and `response.model_version`;
-openai's `ChatCompletion` has neither,
-so the branch raises `AttributeError`
-instead of returning the `'error'` result it means to
-whenever the model spends its whole budget on reasoning.
-It is a copy of the equivalent branch in `call_gemini`
-(`warriors/llms/google.py`), typo in the shared comment included,
-where both attributes do exist.
-Only a `real_world` test reaches `resolve_battle_openai`,
-so nothing exercises the branch.
-Next move: return the `result` and `response.model` values
-the success path a few lines down already uses,
-and cover it with a `respx`-mocked test for `finish_reason == 'length'`,
-shaped like the token-limit tests in `warriors/llms/google_tests.py`.
+The token-limit branch in `call_gemini` (`warriors/llms/google.py`)
+returns the raw `response.text` where the success path two lines down
+returns the `text` it already defaulted to `''`,
+so a candidate carrying no parts leaves the function as `None`
+and `resolve_battle` crashes on `result[:MAX_WARRIOR_LENGTH]`
+(`warriors/tasks.py`) instead of recording an error result.
+Reachable when thinking exhausts the budget
+but a candidate is still emitted —
+the existing `test_google_token_limit_reasoning` covers only
+the no-candidates shape, which returns early.
+Next move: return `text` in that branch,
+and extend the test with a parts-less candidate.
+
+`call_llm` (`warriors/llms/openai.py`) talks to the same endpoint as
+`resolve_battle_openai` but shares none of its defenses:
+no `RateLimitError`/`TransientLLMError` mapping,
+so a rate limit or a 502 escapes raw from the `ensure_name_generated` goal
+and fails it outright instead of earning the retry
+`resolve_battle` gets for the identical condition;
+and it hands `message.content` straight to `generated_name.strip()`
+in `generate_warrior_name` (`warriors/warriors.py`),
+which is `AttributeError` for the null content the schema allows.
+Nothing covers the function.
+Next move: wrap the call in the same two `except` clauses,
+have `ensure_name_generated` return `RetryMeLater` for them,
+default the content to `''`,
+and cover all three with `respx` mocks next to the battle tests.
+This changes behavior — a failed name generation starts retrying — so it needs sign-off.
 
 `warriors/embeddings.py` uses the `voyageai` SDK for a single `embed()` call,
 and since voyageai 0.5.0 that SDK requires

--- a/warriors/llms/openai.py
+++ b/warriors/llms/openai.py
@@ -14,6 +14,15 @@ openai_client = openai.Client(
 )
 
 
+def _llm_version(response):
+    """Which model actually answered.
+
+    Unlike the other providers, openai splits this across two fields -
+    the resolved model name and a fingerprint of the backend behind it.
+    """
+    return response.model + '/' + (response.system_fingerprint or '')
+
+
 def resolve_battle_openai(prompt_a, prompt_b, system_prompt=''):
     messages = []
     if system_prompt:
@@ -43,19 +52,16 @@ def resolve_battle_openai(prompt_a, prompt_b, system_prompt=''):
     else:
         (resp_choice,) = response.choices
         finish_reason = resp_choice.finish_reason
-        result = resp_choice.message.content
+        # content is Optional in the response schema, hence the fallback
+        result = resp_choice.message.content or ''
         if (
             # battle is not valid if we exceed token limit and MAX_WARRIOR_LENGTH is not reached
             # model propably used all the tokens for reasoning
             finish_reason == 'length' and
             len(result) < MAX_WARRIOR_LENGTH
         ):
-            return response.text, 'error', response.model_version
-        return (
-            result,
-            finish_reason,
-            response.model + '/' + (response.system_fingerprint or '')
-        )
+            finish_reason = 'error'
+        return result, finish_reason, _llm_version(response)
 
 
 def call_llm(examples, prompt, system_prompt=None, max_completion_tokens=None):
@@ -84,7 +90,4 @@ def call_llm(examples, prompt, system_prompt=None, max_completion_tokens=None):
         **kwargs,
     )
     (resp_choice,) = response.choices
-    return (
-        resp_choice.message.content,
-        response.model + '/' + (response.system_fingerprint or '')
-    )
+    return resp_choice.message.content, _llm_version(response)

--- a/warriors/llms/openai_tests.py
+++ b/warriors/llms/openai_tests.py
@@ -1,6 +1,90 @@
 import pytest
+import respx
 
+from ..warriors import MAX_WARRIOR_LENGTH
+from .exceptions import RateLimitError, TransientLLMError
 from .openai import resolve_battle_openai
+
+
+openai_endpoint = 'https://api.openai.com/v1/chat/completions'
+
+
+def chat_completion(finish_reason, content, system_fingerprint=None):
+    return {
+        'id': 'chatcmpl-1',
+        'object': 'chat.completion',
+        'created': 1785345620,
+        'model': 'gpt-5-mini-2025-08-07',
+        'system_fingerprint': system_fingerprint,
+        'choices': [{
+            'index': 0,
+            'finish_reason': finish_reason,
+            'message': {'role': 'assistant', 'content': content},
+        }],
+    }
+
+
+@respx.mock
+def test_openai_429():
+    respx.post(openai_endpoint).respond(429)
+    with pytest.raises(RateLimitError):
+        resolve_battle_openai('prompt a', 'prompt b')
+
+
+@respx.mock
+def test_openai_503():
+    respx.post(openai_endpoint).respond(503)
+    with pytest.raises(TransientLLMError):
+        resolve_battle_openai('prompt a', 'prompt b')
+
+
+@respx.mock
+@pytest.mark.parametrize('content', ['', None])
+def test_openai_token_limit_reasoning(content):
+    """This happens when the model never reaches end of reasoning.
+
+    The live endpoint sends an empty string, the schema permits null.
+    """
+    respx.post(openai_endpoint).respond(200, json=chat_completion('length', content))
+    text, finish_reason, llm_version = resolve_battle_openai('prompt a', 'prompt b')
+    assert text == ''
+    assert finish_reason == 'error'
+    assert llm_version == 'gpt-5-mini-2025-08-07/'
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    ('generated_text_len', 'expected_finish_reason'),
+    [
+        (MAX_WARRIOR_LENGTH - 1, 'error'),
+        (MAX_WARRIOR_LENGTH, 'length'),
+    ],
+)
+def test_openai_token_limit_response(generated_text_len, expected_finish_reason):
+    """This happens when the model starts generating response (after CoT) but reaches token limit.
+
+    A response that made it to full length counts, a shorter one doesn't.
+    """
+    respx.post(openai_endpoint).respond(
+        200,
+        json=chat_completion('length', 'a' * generated_text_len),
+    )
+    text, finish_reason, llm_version = resolve_battle_openai('prompt a', 'prompt b')
+    assert text == 'a' * generated_text_len
+    assert finish_reason == expected_finish_reason
+    assert llm_version == 'gpt-5-mini-2025-08-07/'
+
+
+@respx.mock
+def test_openai_stop():
+    """A short answer is fine as long as the model chose to stop."""
+    respx.post(openai_endpoint).respond(200, json=chat_completion(
+        'stop', 'a' * 100, system_fingerprint='fp_deadbeef',
+    ))
+    text, finish_reason, llm_version = resolve_battle_openai('prompt a', 'prompt b')
+    assert text == 'a' * 100
+    assert finish_reason == 'stop'
+    assert llm_version == 'gpt-5-mini-2025-08-07/fp_deadbeef'
 
 
 @pytest.mark.real_world


### PR DESCRIPTION
## Summary

Fix a bug in `resolve_battle_openai` where it referenced non-existent attributes (`response.text` and `response.model_version`) when handling token limit errors, causing `AttributeError` instead of returning the intended error result. Add comprehensive test coverage for OpenAI API responses using `respx` mocks.

## Changes

- **Fix token limit error handling in `resolve_battle_openai`**:
  - Replace invalid `response.text` and `response.model_version` references with correct attributes (`response.model` and `response.system_fingerprint`)
  - Handle optional `message.content` by defaulting to empty string when null
  - Simplify finish_reason logic by setting it to `'error'` when token limit is hit without reaching `MAX_WARRIOR_LENGTH`

- **Extract `_llm_version()` helper**:
  - New function to consistently format LLM version strings across `resolve_battle_openai` and `call_llm`
  - Combines model name with system fingerprint (or empty string if absent)

- **Add comprehensive test suite** (`test_openai_*`):
  - `test_openai_429`: Verify rate limit (429) raises `RateLimitError`
  - `test_openai_503`: Verify service unavailable (503) raises `TransientLLMError`
  - `test_openai_token_limit_reasoning`: Handle empty/null content when model exhausts budget on reasoning
  - `test_openai_token_limit_response`: Distinguish between incomplete responses (error) and full-length responses (length finish_reason)
  - `test_openai_stop`: Verify normal completion with system fingerprint in version string

- **Update TODO.md**: Document the fix and note that `call_llm` needs similar error handling improvements (deferred for separate PR)

## Implementation Details

The tests use `respx` to mock the OpenAI API endpoint and verify correct exception mapping and response handling. The `chat_completion()` helper constructs realistic response payloads matching OpenAI's schema, including optional `system_fingerprint` field.

https://claude.ai/code/session_019AccFtSiVmUDpDBUCX9yzB