### PR TITLE
Handle Gemini rate limits and connection errors, fix token limit logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,9 @@ if it doesn't fit, move detail to the body.
 ## Running tests in Claude Code web environment
 
 The web environment has Python 3.11 as the default, but the project requires
-Python 3.13. PostgreSQL 16 is available but needs to be started manually.
+Python 3.13. PostgreSQL 16 is available but needs to be started manually —
+and again after an idle stretch, which shows up as every database test
+erroring at setup on a failed connection rather than as anything about the code.
 
 ### Setup
 

--- a/TODO.md
+++ b/TODO.md
@@ -106,18 +106,38 @@ onto blank game rows.
 `backfill_game_input_sha256` goes at step 4
 with the columns it copies from.
 
-The token-limit branch in `call_gemini` (`warriors/llms/google.py`)
-returns the raw `response.text` where the success path two lines down
-returns the `text` it already defaulted to `''`,
-so a candidate carrying no parts leaves the function as `None`
-and `resolve_battle` crashes on `result[:MAX_WARRIOR_LENGTH]`
-(`warriors/tasks.py`) instead of recording an error result.
-Reachable when thinking exhausts the budget
-but a candidate is still emitted —
-the existing `test_google_token_limit_reasoning` covers only
-the no-candidates shape, which returns early.
-Next move: return `text` in that branch,
-and extend the test with a parts-less candidate.
+The `thinking_config` that `call_gemini` sends (`warriors/llms/google.py`)
+buys thinking but does not bound it:
+`gemini-flash-lite-latest` resolves to a Gemini 3 model,
+which treats the budget as a hint and reasons into the low thousands of tokens
+whatever number it is given,
+while `thinking_budget=0` is rejected outright with a 400.
+`max_output_tokens` is the only real cap,
+and reasoning shares it with the answer,
+so a reasoning-heavy pair of warriors can spend the whole cap thinking
+and resolve as an error.
+The dial that does work is binary —
+sending no `thinking_config` at all stops the thinking
+on every prompt measured — which is a change to battle outcomes,
+so it needs sign-off, as does trading the budget for `thinking_level`.
+Next move: pick one and record the reasoning
+in the reasoning-tokens item of `docs/strategy.md`,
+which owns why the spend is deliberate.
+
+The three connectors (`warriors/llms/`) each spell out the same policy
+in their own provider's dialect:
+rate limit to `RateLimitError`, server and transport failures
+to `TransientLLMError`, everything else out raw,
+and — for the two that reason — a token limit reached with less than
+`MAX_WARRIOR_LENGTH` of text downgraded to the `'error'` sentinel.
+Nothing names that contract or that sentinel in one place,
+so the defenses get audited and repaired one provider at a time;
+anthropic has no downgrade at all,
+having no reasoning that can run past its cap.
+Next move: state the `(text, finish_reason, llm_version)` contract
+and the meaning of `'error'` where the shared exceptions live
+(`warriors/llms/exceptions.py`),
+and give the downgrade one home the connectors call.
 
 `call_llm` (`warriors/llms/openai.py`) talks to the same endpoint as
 `resolve_battle_openai` but shares none of its defenses:

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -43,8 +43,13 @@ Where the money actually goes, in order:
    a thinking referee is harder to hijack,
    and resistance to manipulation is the game's difficulty setting
    (see the data–instruction separation theme in `docs/parallels.md`).
-   The thinking budget is a game-design dial that happens to cost money,
+   Whether the referee thinks at all is a game-design dial
+   that happens to cost money,
    priced at roughly €15–20/month for a smarter adversary.
+   On the Gemini side that dial is close to binary:
+   the requested budget is a hint the model reasons past,
+   so the choice is whether to ask for thinking, not how much
+   (see the `thinking_config` note in `warriors/llms/google.py`).
    Levers that leave the referee untouched: discounted pricing tiers.
    OpenAI's flex service tier
    (in beta — verify model coverage before relying on it)

--- a/warriors/llms/google.py
+++ b/warriors/llms/google.py
@@ -1,15 +1,15 @@
 import logging
 
-import requests
+import httpx
 from django.conf import settings
 from google import genai
-from google.genai.errors import ServerError
+from google.genai.errors import ClientError, ServerError
 from google.genai.types import (
     FinishReason, GenerateContentConfig, ThinkingConfig,
 )
 
 from ..warriors import MAX_WARRIOR_LENGTH
-from .exceptions import TransientLLMError
+from .exceptions import RateLimitError, TransientLLMError
 
 
 logger = logging.getLogger(__name__)
@@ -34,26 +34,33 @@ def call_gemini(prompt):
                 # we allow for 1x thinking tokens and 1x output tokens, additional 1x for margin
                 max_output_tokens=MAX_WARRIOR_LENGTH * 3,
                 thinking_config=ThinkingConfig(
+                    # a hint the model reasons past, not a cap - max_output_tokens is the cap
                     thinking_budget=MAX_WARRIOR_LENGTH * 1,
                 ),
             ),
         )
-        candidates = response.candidates
-        if not candidates:
-            return '', 'error', response.model_version
-        finish_reason = candidates[0].finish_reason
-        if finish_reason is None:
-            raise TransientLLMError('Mode has not stoped generating tokens, whatever that means')
-        text = response.text or ''
+    except ClientError as e:
+        if e.code == 429:
+            raise RateLimitError() from e
+        raise
+    except (ServerError, httpx.TransportError) as e:
+        # the SDK's httpx transport never retries, so its resets and timeouts land here raw too
+        raise TransientLLMError() from e
+
+    # None whenever no candidate carries a text part - what reasoning eating the whole budget looks like
+    text = response.text or ''
+    candidate = response.candidates[0] if response.candidates else None
+    if candidate is None:
+        finish_reason = 'error'
+    elif candidate.finish_reason is None:
+        raise TransientLLMError('Mode has not stoped generating tokens, whatever that means')
+    else:
+        finish_reason = candidate.finish_reason.value
         if (
             # battle is not valid if we exceed token limit and MAX_WARRIOR_LENGTH is not reached
             # model propably used all the tokens for reasoning
-            finish_reason == FinishReason.MAX_TOKENS and
+            finish_reason == FinishReason.MAX_TOKENS.value and
             len(text) < MAX_WARRIOR_LENGTH
         ):
-            return response.text, 'error', response.model_version
-        return text, finish_reason.value, response.model_version
-    except ServerError as e:
-        raise TransientLLMError() from e
-    except requests.RequestException as e:
-        raise TransientLLMError() from e
+            finish_reason = 'error'
+    return text, finish_reason, response.model_version

--- a/warriors/llms/google_tests.py
+++ b/warriors/llms/google_tests.py
@@ -1,11 +1,20 @@
+import httpx
 import pytest
 import respx
 
-from .exceptions import TransientLLMError
+from ..warriors import MAX_WARRIOR_LENGTH
+from .exceptions import RateLimitError, TransientLLMError
 from .google import call_gemini
 
 
 gemini_endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent'
+
+
+@respx.mock
+def test_google_429():
+    respx.post(gemini_endpoint).respond(429)
+    with pytest.raises(RateLimitError):
+        call_gemini('prompt')
 
 
 @respx.mock
@@ -16,8 +25,16 @@ def test_google_503():
 
 
 @respx.mock
-def test_google_token_limit_reasoning():
-    """This happens when the model never reaches end of reasoning."""
+def test_google_connection_error():
+    """The SDK talks over httpx and never retries, so the transport error reaches us."""
+    respx.post(gemini_endpoint).mock(side_effect=httpx.ConnectError)
+    with pytest.raises(TransientLLMError):
+        call_gemini('prompt')
+
+
+@respx.mock
+def test_google_no_candidates():
+    """Nothing was generated at all - nothing to score, and nothing a retry would fix."""
     respx.post(gemini_endpoint).respond(
         200,
         json={
@@ -32,16 +49,38 @@ def test_google_token_limit_reasoning():
 
 
 @respx.mock
+def test_google_token_limit_reasoning():
+    """This is what reasoning eating the whole output budget looks like on the live endpoint.
+
+    An empty content object - no parts at all - is where `response.text` is None, not ''.
+    """
+    respx.post(gemini_endpoint).respond(
+        200,
+        json={
+            'candidates': [{'content': {}, 'finishReason': 'MAX_TOKENS', 'index': 0}],
+            'usageMetadata': {'promptTokenCount': 52, 'thoughtsTokenCount': 29, 'totalTokenCount': 81},
+            'modelVersion': 'gemini-3.5-flash-lite',
+        }
+    )
+    text, finish_reason, llm_version = call_gemini('prompt')
+    assert text == ''
+    assert finish_reason == 'error'
+    assert llm_version == 'gemini-3.5-flash-lite'
+
+
+@respx.mock
 @pytest.mark.parametrize(
     ('generated_text_len', 'expected_finish_reason'),
     [
-        (100, 'error'),
-        (1000, 'MAX_TOKENS'),
-        (10000, 'MAX_TOKENS'),
+        (MAX_WARRIOR_LENGTH - 1, 'error'),
+        (MAX_WARRIOR_LENGTH, 'MAX_TOKENS'),
     ],
 )
 def test_google_token_limit_response(generated_text_len, expected_finish_reason):
-    """This happens when the model starts generating response (after CoT) but reaches token limit."""
+    """This happens when the model starts generating response (after CoT) but reaches token limit.
+
+    A response that made it to full length counts, a shorter one doesn't.
+    """
     respx.post(gemini_endpoint).respond(
         200,
         json={
@@ -85,6 +124,7 @@ def test_google_no_finish_reason():
 
 @respx.mock
 def test_google_no_text():
+    """A reason other than the token limit stands even when nothing was generated."""
     respx.post(gemini_endpoint).respond(
         200,
         json={
@@ -97,3 +137,11 @@ def test_google_no_text():
     assert text == ''
     assert finish_reason == 'RECITATION'
     assert llm_version == 'gemini-2.0-flash-thinking-exp-01-21'
+
+
+@pytest.mark.real_world
+def test_call_gemini_real_endpoint():
+    text, finish_reason, llm_version = call_gemini('Test text')
+    assert isinstance(text, str)
+    assert isinstance(finish_reason, str)
+    assert isinstance(llm_version, str)


### PR DESCRIPTION
Improve error handling in the Gemini connector and fix the token limit detection logic that was causing crashes when reasoning exhausted the output budget.

**Changes:**

- **Error handling**: Catch `ClientError` with code 429 and raise `RateLimitError`; catch `ServerError` and `httpx.TransportError` and raise `TransientLLMError`. Switch from `requests` to `httpx` to match the SDK's transport layer.

- **Token limit logic**: Fix the case where reasoning consumes the entire output budget, leaving an empty candidate with no text parts. `response.text` is `None` in this case (not `''`), which was causing `resolve_battle` to crash on `result[:MAX_WARRIOR_LENGTH]`. Now return `''` with finish reason `'error'` when no candidate exists or when `MAX_TOKENS` is reached with less than `MAX_WARRIOR_LENGTH` of text.

- **Tests**: Add tests for 429 rate limit, connection errors, and the no-candidates case. Refactor the token limit test to use `MAX_WARRIOR_LENGTH` constant instead of magic numbers, making the threshold explicit. Add a real-world integration test.

- **Documentation**: Update `TODO.md` to document the thinking budget behavior (a hint, not a cap) and the emerging pattern across connectors: rate limit → `RateLimitError`, transient failures → `TransientLLMError`, token limit with insufficient output → `'error'` sentinel. Note that this contract and sentinel need a single home in `warriors/llms/exceptions.py`. Update `docs/strategy.md` to clarify that the thinking dial is nearly binary on Gemini (ask or don't ask, not how much).

- **Docs**: Clarify in `AGENTS.md` that PostgreSQL may need restarting after idle periods in the Claude Code environment.

https://claude.ai/code/session_01DurCptAZrCXkT32ZiWSiXx