### PR TITLE
Re-key GameScore from (battle, direction) to game

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,6 +105,28 @@ a repair command that recomputes the sha from the warrior bodies
 onto blank game rows.
 `backfill_game_input_sha256` goes with the columns it copies from.
 
+`backfill_game_score_game` is a one-time re-keying,
+not an ongoing repair:
+it links the `GameScore` rows written before the `game` column existed
+to the game row their (battle, direction) pair already names.
+Delete it once a production run reports zero still unlinked —
+the same condition that lets the column go not-null
+in step 1 of `docs/game-migration.md`,
+so the two land together.
+
+Every test that builds a `Battle` has to sort the warrior pair first,
+because `BattleFactory` passes its two `SubFactory` warriors through
+in the order given and the `warrior_ordering` check constraint
+demands the smaller id first —
+so a bare `BattleFactory()` fails about half the time,
+and five call sites
+(`warriors/tests/fixtures.py` twice, `batch_create_battles`,
+`create_mirrored_battle`, and the rating tests)
+repeat the same three-line swap.
+Next move: swap the pair in a `_adjust_kwargs` classmethod on the factory
+and delete the swaps at the call sites;
+behavior-preserving for every test that already sorts.
+
 The `thinking_config` that `call_gemini` sends (`warriors/llms/google.py`)
 buys thinking but does not bound it:
 `gemini-flash-lite-latest` resolves to a Gemini 3 model,
@@ -192,6 +214,9 @@ They rot invisibly:
 `backfill_sha.py` cites a `verify_ordering.py` that is not in the tree,
 and it writes `Battle.input_sha256_*` without the matching game rows —
 the blanks `backfill_game_input_sha256` exists to fill.
+`create_game_score.py` and `set_game_score.py` key `GameScore`
+on (battle, direction), which the re-keying in
+`docs/game-migration.md` drops out from under them.
 Next move: for each, decide between
 a management command next to `warriors/management/commands/verify_games.py`
 if the operation is still worth running,

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -111,10 +111,13 @@ A finding nothing explains is a bug to chase, not data to copy over.
 
 ### 1. Re-key GameScore
 
-Add a nullable `game` foreign key to `GameScore`,
-dual-written in `get_or_create_game_score` (`warriors/score.py`);
-backfill from (battle, direction);
-move the uniqueness to (game, algorithm).
+`get_or_create_game_score` (`warriors/score.py`)
+names the game on every score it writes,
+and `backfill_game_score_game` links the rows written before it did.
+Once a production run reports nothing left to link,
+the column goes not-null
+and the lookup and the uniqueness move off (battle, direction)
+onto the (game, algorithm) constraint that already guards the writes.
 `_ensure_score` then reads the game row directly —
 warriors, result text unit, finish reason —
 instead of constructing the battle facade.

--- a/warriors/management/commands/backfill_game_score_game.py
+++ b/warriors/management/commands/backfill_game_score_game.py
@@ -1,0 +1,71 @@
+"""
+Point older `GameScore` rows at the game row they score.
+
+`get_or_create_game_score` names the game on every row it writes,
+but the rows that predate the column carry only (battle, direction).
+The game row is what they identify — the pair maps to it one-to-one —
+so this is a re-keying, not a repair: no value is chosen, only looked up.
+
+Set-based, batched by score id, each batch its own transaction,
+so it holds no long locks and can be interrupted and rerun.
+The two directions are separate statements:
+one statement would need a CASE over the swapped warrior pair
+to say which end of the battle the direction starts from.
+
+Delete this command once a production run reports nothing left to link:
+the not-null migration that follows leaves it nothing to find.
+"""
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+
+from ...score import GameScore
+
+
+LINK_SQL = """
+    UPDATE warriors_gamescore s
+    SET game_id = g.id
+    FROM warriors_battle b, warriors_game g
+    WHERE s.id = ANY(%(ids)s)
+      AND s.game_id IS NULL
+      AND s.direction = %(direction)s
+      AND b.id = s.battle_id
+      AND g.battle_id = b.id
+      AND g.warrior_1_id = b.{first}
+"""
+DIRECTIONS = (
+    ('1_2', 'warrior_1_id'),
+    ('2_1', 'warrior_2_id'),
+)
+
+
+class Command(BaseCommand):
+    help = 'Link game scores to the game row they score'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--batch-size', type=int, default=10000)
+
+    def handle(self, *args, batch_size, **options):
+        scanned = 0
+        linked = 0
+        last_id = None
+        while True:
+            scores = GameScore.objects.filter(game=None).order_by('id')
+            if last_id is not None:
+                scores = scores.filter(id__gt=last_id)
+            ids = list(scores.values_list('id', flat=True)[:batch_size])
+            if not ids:
+                break
+            last_id = ids[-1]
+            scanned += len(ids)
+            with transaction.atomic(), connection.cursor() as cursor:
+                for direction, first in DIRECTIONS:
+                    cursor.execute(
+                        LINK_SQL.format(first=first),
+                        {'ids': ids, 'direction': direction},
+                    )
+                    linked += cursor.rowcount
+            self.stdout.write(f'scanned {scanned}, linked {linked}')
+        unlinked = GameScore.objects.filter(game=None).count()
+        # what is left is a score whose battle direction has no game row:
+        # a broken invariant for verify_games to report, not a gap to fill
+        self.stdout.write(f'done: linked {linked}, {unlinked} still unlinked')

--- a/warriors/migrations/0060_gamescore_game.py
+++ b/warriors/migrations/0060_gamescore_game.py
@@ -1,0 +1,33 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('warriors', '0059_dbgame_battle_not_null'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gamescore',
+            name='game',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='scores',
+                to='warriors.dbgame',
+            ),
+        ),
+        # Null game rows are exempt from the constraint,
+        # so it guards the dual-write in get_or_create_game_score
+        # from day one while legacy rows await backfill_game_score_game.
+        migrations.AddConstraint(
+            model_name='gamescore',
+            constraint=models.UniqueConstraint(
+                fields=('game', 'algorithm'),
+                name='unique_game_algorithm',
+            ),
+        ),
+    ]

--- a/warriors/score.py
+++ b/warriors/score.py
@@ -28,6 +28,13 @@ class GameScore(GoalRelatedMixin, models.Model):
         on_delete=models.CASCADE,
         related_name='game_scores',
     )
+    game = models.ForeignKey(
+        to='DBGame',
+        on_delete=models.CASCADE,
+        related_name='scores',
+        null=True,
+        blank=True,
+    )
     direction = models.CharField(
         max_length=3,
         choices=[
@@ -62,18 +69,37 @@ class GameScore(GoalRelatedMixin, models.Model):
         indexes = [
             models.Index(fields=['battle', 'direction', 'algorithm']),
         ]
+        constraints = [
+            # the key that replaces the pair above; rows with no game yet
+            # are exempt until backfill_game_score_game has run
+            models.UniqueConstraint(
+                fields=('game', 'algorithm'),
+                name='unique_game_algorithm',
+            ),
+        ]
 
 
-def get_or_create_game_score(battle, direction, algorithm):
+def get_or_create_game_score(game, direction, algorithm):
+    """
+    The score of one game under one algorithm.
+
+    The lookup keys on (battle, direction) though the write names the game:
+    a score written before the column existed carries no game,
+    so keying the lookup on it would miss that score
+    and create a duplicate the old uniqueness rejects.
+    `direction` is that key's other half, and drops with it
+    once `backfill_game_score_game` has run (docs/game-migration.md).
+    """
     game_score = GameScore.objects.filter(
-        battle=battle,
+        battle_id=game.battle_id,
         direction=direction,
         algorithm=algorithm,
     ).first()
     if game_score is None:
         game_score = GameScore.objects.create(
-            battle=battle,
+            battle_id=game.battle_id,
             direction=direction,
+            game=game,
             algorithm=algorithm,
             processed_goal=schedule(ensure_score),
         )

--- a/warriors/score_tests.py
+++ b/warriors/score_tests.py
@@ -5,7 +5,7 @@ import pytest
 from django_goals.busy_worker import worker
 
 from .score import GameScoreViewpoint, ScoreAlgorithm, get_or_create_game_score
-from .tests.factories import TextUnitFactory
+from .tests.factories import TextUnitFactory, game_of
 
 
 @pytest.mark.django_db
@@ -34,7 +34,7 @@ def test_gamescore_embeddings_integration(battle, direction):
 
     # Create a game score with Embeddings algorithm
     game_score = get_or_create_game_score(
-        battle=battle,
+        game=game_of(battle, direction),
         direction=direction,
         algorithm=ScoreAlgorithm.EMBEDDINGS,
     )
@@ -89,7 +89,7 @@ def test_gamescore_lcs(battle, direction):
 
     # Create a game score with LCS algorithm
     game_score = get_or_create_game_score(
-        battle=battle,
+        game=game_of(battle, direction),
         direction=direction,
         algorithm=ScoreAlgorithm.LCS,
     )

--- a/warriors/tasks.py
+++ b/warriors/tasks.py
@@ -133,8 +133,8 @@ def resolve_battle(goal, battle_id, direction):
             assert game.resolved_at is not None
             return RetryMeLater(message='Ran LLM')
 
-    score_lcs = get_or_create_game_score(battle, direction, ScoreAlgorithm.LCS)
-    score_embedings = get_or_create_game_score(battle, direction, ScoreAlgorithm.EMBEDDINGS)
+    score_lcs = get_or_create_game_score(game, direction, ScoreAlgorithm.LCS)
+    score_embedings = get_or_create_game_score(game, direction, ScoreAlgorithm.EMBEDDINGS)
     missing_scores = [
         score for score in [score_lcs, score_embedings]
         if not score.is_completed

--- a/warriors/tests/factories.py
+++ b/warriors/tests/factories.py
@@ -104,6 +104,20 @@ class TextUnitFactory(factory.django.DjangoModelFactory):
     )
 
 
+def game_of(battle, direction):
+    """The game row that plays the battle out in the given direction."""
+    return battle.games.get(
+        warrior_1_id=(
+            battle.warrior_1_id if direction == '1_2'
+            else battle.warrior_2_id
+        ),
+    )
+
+
 class GameScoreFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = GameScore
+
+    # what get_or_create_game_score writes: the pair and the game row it
+    # names, so a test row is shaped like a production one
+    game = factory.LazyAttribute(lambda score: game_of(score.battle, score.direction))

--- a/warriors/tests/test_backfill_game_score_game.py
+++ b/warriors/tests/test_backfill_game_score_game.py
@@ -1,0 +1,23 @@
+import pytest
+from django.core.management import call_command
+
+from ..score import GameScore
+from .factories import game_of
+from .fixtures import create_scores
+from .test_verify_games import create_mirrored_battle
+
+
+@pytest.mark.django_db
+def test_backfill_links_each_score_to_its_own_game():
+    # two battles, because the join has to pick the game row by battle
+    # as well as by direction
+    battles = [create_mirrored_battle() for _ in range(2)]
+    for battle in battles:
+        create_scores(battle, 1, 0.1, 1, 0.1)
+    GameScore.objects.update(game=None)
+
+    call_command('backfill_game_score_game', batch_size=1)
+
+    for battle in battles:
+        for score in battle.game_scores.all():
+            assert score.game == game_of(battle, score.direction)

--- a/warriors/tests/test_e2e.py
+++ b/warriors/tests/test_e2e.py
@@ -103,6 +103,10 @@ def test_battle_from_warriors_e2e(monkeypatch, warrior_arena, other_warrior_aren
     assert db_game_1_2.llm_version == 'gpt-3.5/1234'
     assert db_game_2_1.llm_version == 'gpt-3.5/1234'
 
+    # each direction's scores name the game they score, not just the pair
+    assert db_game_1_2.scores.count() == 2
+    assert db_game_2_1.scores.count() == 2
+
 
 @pytest.mark.django_db
 def test_battle_retry(battle, monkeypatch):


### PR DESCRIPTION
Adds a `game` foreign key to `GameScore` and re-keys the uniqueness constraint from `(battle, direction, algorithm)` to `(game, algorithm)`.
This is step 1 of the game migration in `docs/game-migration.md`:
the column is added nullable,
`get_or_create_game_score` dual-writes it,
and a new backfill command links rows written before the column existed.

**Key changes:**

- Add nullable `game` foreign key to `GameScore` model with a unique constraint on `(game, algorithm)` that exempts null rows until backfill completes
- Update `get_or_create_game_score` to accept a `game` parameter instead of `battle` and write the game row on creation
- Add `backfill_game_score_game` management command to link legacy `GameScore` rows (those with `game=None`) to their game row via the `(battle, direction)` pair
- Update all call sites (`resolve_battle`, `score_tests.py`) to pass the game row instead of battle
- Add `game_of()` helper in factories to look up the game row for a given battle and direction
- Update `GameScoreFactory` to write the game row like production code does
- Add test for the backfill command
- Update `docs/game-migration.md` to reflect the completed step and document the backfill condition for deletion

The backfill is set-based and batched by score id, each batch in its own transaction, so it holds no long locks and can be interrupted and rerun.
Once a production run reports zero unlinked scores, the column can go not-null and the lookup can move entirely to the game row.

https://claude.ai/code/session_01UqX8xN5MrEznaz1MG4UPG5