### PR TITLE
Add warrior-scoped battle navigation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -226,3 +226,17 @@ For `backfill_sha.py` the decision is settled:
 its recompute-from-bodies logic moves into
 the game-row sha repair command (see the `input_sha256` entry),
 and the script goes.
+
+The arena-wide half of `battle_nav_urls` (`warriors/views.py`)
+picks its battles two ways the warrior-scoped half does not.
+It joins `arena__llm` where `llm` is a column on the battle itself,
+and `Battle.arena` is nullable,
+so a battle with no arena drops out of the walk silently.
+It also runs the queryset through `for_user`,
+which narrows a signed-in visitor to battles of their own warriors:
+the same page then offers different neighbours to different people,
+and often none at all to someone reading a stranger's battle,
+while an anonymous visitor walks everything.
+Next move: filter `llm=battle.llm` directly and drop the `for_user` call,
+leaving both halves scoped by nothing but what is being browsed.
+Both are behavior changes, so they need sign-off.

--- a/templates/warriors/battle_detail.html
+++ b/templates/warriors/battle_detail.html
@@ -24,13 +24,20 @@
       <nav>
         <ul>
           <li>
-            {% if previous_battle %}
-              <a href="{% url 'battle_detail' previous_battle.id %}">↶ Older battle</a>
+            {% if previous_battle_url %}
+              <a href="{{ previous_battle_url }}">↶ Older battle</a>
             {% endif %}
           </li>
+          {% if nav_warrior_arena %}
+            <li>
+              <a href="{% url 'warrior_detail' nav_warrior_arena.id %}">
+                All battles of {{ nav_warrior_arena }}
+              </a>
+            </li>
+          {% endif %}
           <li>
-            {% if next_battle %}
-              <a href="{% url 'battle_detail' next_battle.id %}">Newer battle ↷</a>
+            {% if next_battle_url %}
+              <a href="{{ next_battle_url }}">Newer battle ↷</a>
             {% endif %}
           </li>
         </ul>

--- a/templates/warriors/warriorarena_detail.html
+++ b/templates/warriors/warriorarena_detail.html
@@ -67,14 +67,14 @@
         <tbody>
           {% for battle in battles %}
             <tr>
-              <td><a href="{% url 'battle_detail' battle.id %}?{{ request.GET.urlencode }}">
+              <td><a href="{% url 'battle_detail' battle.id %}?warrior_arena={{ warrior.id }}">
                 {% include 'time.html' with time=battle.scheduled_at %}
               </a></td>
-              <td><a href="{% url 'battle_detail' battle.id %}?{{ request.GET.urlencode }}">
+              <td><a href="{% url 'battle_detail' battle.id %}?warrior_arena={{ warrior.id }}">
                 {{ battle.warrior_2 }}
               </a></td>
               <td>
-                <a href="{% url 'battle_detail' battle.id %}?{{ request.GET.urlencode }}#{{ battle.game_1_id }}">
+                <a href="{% url 'battle_detail' battle.id %}?warrior_arena={{ warrior.id }}#{{ battle.game_1_id }}">
                   {% if not battle.resolved_at_1_2 %}
                     <i>pending</i>
                   {% else %}
@@ -83,7 +83,7 @@
                 </a>
               </td>
               <td>
-                <a href="{% url 'battle_detail' battle.id %}?{{ request.GET.urlencode }}#{{ battle.game_2_id }}">
+                <a href="{% url 'battle_detail' battle.id %}?warrior_arena={{ warrior.id }}#{{ battle.game_2_id }}">
                   {% if not battle.resolved_at_2_1 %}
                     <i>pending</i>
                   {% else %}

--- a/warriors/tests/test_views.py
+++ b/warriors/tests/test_views.py
@@ -1,3 +1,6 @@
+import datetime
+import uuid
+
 import pytest
 from django.urls import reverse
 from django.utils import timezone
@@ -210,6 +213,66 @@ def test_battle_details_error(user_client, battle, warrior_user_permission):
     assert response.status_code == 200
     game = response.context['battle'].game_1_2
     assert game.show_secrets_1 or game.show_secrets_2
+
+
+def schedule_in_order(*battles):
+    """Space battles a day apart, oldest first, so nav order is not left to chance."""
+    now = timezone.now()
+    for days, battle in enumerate(reversed(battles), start=1):
+        battle.scheduled_at = now - datetime.timedelta(days=days)
+        battle.save(update_fields=['scheduled_at'])
+
+
+def battle_url(battle, warrior_arena=None):
+    url = reverse('battle_detail', args=(battle.id,))
+    if warrior_arena is not None:
+        url += f'?warrior_arena={warrior_arena.id}'
+    return url
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('scoped', [True, False])
+def test_battle_details_nav(client, arena, warrior_arena, scoped):
+    """The warrior parameter is what keeps a stranger's battle out of the walk."""
+    older, middle, newer = batch_create_battles(arena, warrior_arena, 3)
+    stranger = batch_create_battles(arena, WarriorArenaFactory(arena=arena), 1)[0]
+    schedule_in_order(older, middle, stranger, newer)
+
+    nav_warrior = warrior_arena if scoped else None
+    response = client.get(battle_url(middle, nav_warrior))
+
+    assert response.status_code == 200
+    assert response.context['nav_warrior_arena'] == nav_warrior
+    assert response.context['previous_battle_url'] == battle_url(older, nav_warrior)
+    assert response.context['next_battle_url'] == battle_url(
+        newer if scoped else stranger, nav_warrior,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('bad_value', [
+    lambda arena: 'not-a-uuid',
+    lambda arena: str(uuid.uuid4()),
+    lambda arena: str(WarriorArenaFactory(arena=arena).id),
+], ids=['malformed', 'unknown', 'stranger'])
+def test_battle_details_nav_unrecognized_warrior(client, arena, battle, bad_value):
+    response = client.get(
+        reverse('battle_detail', args=(battle.id,)),
+        data={'warrior_arena': bad_value(arena)},
+    )
+    assert response.status_code == 200
+    assert response.context['nav_warrior_arena'] is None
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('battle', [{
+    'resolved_at_1_2': timezone.now(),
+}], indirect=True)
+def test_warrior_details_links_carry_the_warrior(client, warrior_arena, battle):
+    response = client.get(
+        reverse('warrior_detail', args=(warrior_arena.id,))
+    )
+    assert battle_url(battle, warrior_arena) in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/warriors/views.py
+++ b/warriors/views.py
@@ -1,9 +1,13 @@
+import uuid
+
 from django import forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils.http import urlencode
 from django.views.decorators.http import require_POST
 from django.views.generic.base import ContextMixin
 from django.views.generic.detail import DetailView
@@ -234,18 +238,62 @@ class BattleDetailView(DetailView):
         self.object.game_2_1.show_secrets_2 = show_secrets_1
         self.object.game_2_1.show_battle_results = show_battle_results
 
-        # find prev/next battles
-        battles_qs = Battle.objects.for_user(self.request.user).filter(
-            arena__llm=self.object.llm,
+        warrior_arena = self.get_nav_warrior_arena()
+        context['nav_warrior_arena'] = warrior_arena
+        context['previous_battle_url'], context['next_battle_url'] = battle_nav_urls(
+            self.object, warrior_arena, self.request.user,
         )
-        context['next_battle'] = battles_qs.filter(
-            scheduled_at__gt=self.object.scheduled_at,
-        ).order_by('scheduled_at').only('id', 'scheduled_at').first()
-        context['previous_battle'] = battles_qs.filter(
-            scheduled_at__lt=self.object.scheduled_at,
-        ).order_by('-scheduled_at').only('id', 'scheduled_at').first()
 
         return context
+
+    def get_nav_warrior_arena(self):
+        """
+        The warrior named by the `warrior_arena` query parameter, if it fought here.
+
+        The warrior page puts the parameter on every link into a battle,
+        so that stepping onward from there stays in the list it showed.
+        A value naming no warrior of this battle names no warrior at all.
+        """
+        try:
+            warrior_arena_id = uuid.UUID(self.request.GET.get('warrior_arena', ''))
+        except ValueError:
+            return None
+        warrior_arena = WarriorArena.objects.filter(
+            id=warrior_arena_id,
+        ).select_related('arena').first()
+        if warrior_arena is None:
+            return None
+        if warrior_arena.warrior_id not in (self.object.warrior_1_id, self.object.warrior_2_id):
+            return None
+        return warrior_arena
+
+
+def battle_nav_urls(battle, warrior_arena, user):
+    """
+    Links to the battles either side of this one in time, older first.
+
+    Given a warrior, they walk that warrior's battles —
+    the list `WarriorDetailView` shows, so the two pages agree on
+    what comes next — and carry the warrior onward.
+    Without one they walk the arena, and the battle URL stands alone.
+    """
+    if warrior_arena is None:
+        battles = Battle.objects.for_user(user).filter(arena__llm=battle.llm)
+    else:
+        battles = Battle.objects.with_warrior_arena(warrior_arena)
+    battles = battles.only('id', 'scheduled_at')
+    older = battles.filter(scheduled_at__lt=battle.scheduled_at).order_by('-scheduled_at').first()
+    newer = battles.filter(scheduled_at__gt=battle.scheduled_at).order_by('scheduled_at').first()
+    return battle_nav_url(older, warrior_arena), battle_nav_url(newer, warrior_arena)
+
+
+def battle_nav_url(neighbour, warrior_arena):
+    if neighbour is None:
+        return None
+    url = reverse('battle_detail', args=(neighbour.id,))
+    if warrior_arena is not None:
+        url += '?' + urlencode({'warrior_arena': warrior_arena.id})
+    return url
 
 
 class WarriorLeaderboard(ArenaViewMixin, ListView):


### PR DESCRIPTION
Closes #6.

Inspecting a warrior's battle history meant opening each row in a new tab
or going back to the warrior page between battles:
the prev/next links on a battle stepped through every battle on the arena's LLM,
a different list than the one the visitor arrived from.

The warrior page now names itself in every link into a battle
(`?warrior_arena=<id>`),
and the battle page walks that warrior's battles when it does,
plus offers a way back to the full list.
A link without the parameter keeps the arena-wide walk,
so the battle URL stays shareable and stands alone.

## Changes

- `battle_nav_urls()` in `warriors/views.py` picks the queryset and finds both neighbours;
  with a warrior it uses `Battle.objects.with_warrior_arena()`,
  the same list `WarriorDetailView` shows,
  so the two pages agree on what comes next.
- `BattleDetailView.get_nav_warrior_arena()` reads the parameter.
  A malformed UUID, an unknown id,
  or a warrior that never fought this battle all resolve to no warrior,
  and navigation falls back to the arena.
- `battle_detail.html` renders the prebuilt URLs
  so the parameter is carried onward,
  and links back to the warrior when scoped.
- `warriorarena_detail.html` emits the parameter on its four battle links,
  replacing a `{{ request.GET.urlencode }}` passthrough
  that nothing ever set parameters for.

## Tests

`test_battle_details_nav` is parametrized on scoped/unscoped
and plants a stranger's battle between two of the warrior's:
the same page and the same data,
with one parameter deciding whether next is the warrior's battle or the stranger's.
`test_battle_details_nav_unrecognized_warrior` covers the three ways
the parameter can fail to name a warrior of this battle —
the `stranger` case guards against hand-crafting a URL
that hangs an unrelated warrior's navigation on a battle.
`test_warrior_details_links_carry_the_warrior` ties the parameter name
across the two pages, so a one-sided rename fails.

## Note on the TODO entry

The entry added to `TODO.md` is **not** a pair of safe cleanups.
The arena-wide branch narrows itself two ways the warrior-scoped branch does not,
and undoing either changes behavior and needs sign-off:
filtering `llm=battle.llm` directly instead of joining `arena__llm`
pulls arena-less battles into the walk that are currently excluded,
and dropping `for_user()` changes which battles a signed-in visitor can walk.