### PR TITLE
Find the neighbour battle on click, not on render

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -227,18 +227,18 @@ its recompute-from-bodies logic moves into
 the game-row sha repair command (see the `input_sha256` entry),
 and the script goes.
 
-The arena walk in `battle_nav_context` (`warriors/views.py`)
+The arena walk in `battle_nav` (`warriors/views.py`)
 picks its battles two ways the warrior walk beside it does not.
 It joins `arena__llm` where `llm` is a column on the battle itself,
 and `Battle.arena` is nullable,
 so a battle with no arena drops out of the walk silently.
 It also runs the queryset through `for_user`,
 which narrows a signed-in visitor to battles of their own warriors:
-the same page then offers different neighbours to different people,
-and often none at all to someone reading a stranger's battle,
+the same link then leads different people to different neighbours,
+and a signed-in visitor reading a stranger's battle usually to a 404,
 while an anonymous visitor walks everything.
-Now that the arena walk is the one nav every battle page carries,
-that is the difference between a page with neighbours and a dead end.
+The arena walk is the one nav every battle page carries,
+so that is the difference between a page one can step off and a dead end.
 Next move: filter `llm=battle.llm` directly and drop the `for_user` call,
 leaving both walks scoped by nothing but what is being browsed.
 Both are behavior changes, so they need sign-off.
@@ -246,7 +246,7 @@ Both are behavior changes, so they need sign-off.
 The `warrior_arena` query parameter that carries a warrior into a battle page
 is spelled out in three places that must agree:
 `battle_url` builds it (`warriors/views.py`),
-`BattleDetailView.get_nav_warrior_arena` reads it,
+`get_nav_warrior_arena` reads it,
 and `warriorarena_detail.html` hand-writes
 `?warrior_arena={{ warrior.id }}` onto four links.
 Rename the parameter and the template links keep pointing at the old name,

--- a/llm_wars/urls.py
+++ b/llm_wars/urls.py
@@ -80,6 +80,10 @@ urlpatterns = (
     ),
     path('challenge/<uuid:pk>/', ChallengeWarriorView.as_view(), name='challenge_warrior'),
     path('battle/<uuid:pk>/', BattleDetailView.as_view(), name='battle_detail'),
+    path('battle/<uuid:pk>/arena/previous/', warriors.views.previous_arena_battle, name='previous_arena_battle'),
+    path('battle/<uuid:pk>/arena/next/', warriors.views.next_arena_battle, name='next_arena_battle'),
+    path('battle/<uuid:pk>/warrior/previous/', warriors.views.previous_warrior_battle, name='previous_warrior_battle'),
+    path('battle/<uuid:pk>/warrior/next/', warriors.views.next_warrior_battle, name='next_warrior_battle'),
 
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),

--- a/templates/warriors/battle_detail.html
+++ b/templates/warriors/battle_detail.html
@@ -25,9 +25,7 @@
         <nav aria-label="Battles of {{ nav_warrior_arena }}">
           <ul>
             <li>
-              {% if warrior_previous_battle_url %}
-                <a href="{{ warrior_previous_battle_url }}">↶ Older battle of {{ nav_warrior_arena }}</a>
-              {% endif %}
+              <a href="{{ warrior_previous_battle_url }}">↶ Older battle of {{ nav_warrior_arena }}</a>
             </li>
             <li>
               <a href="{% url 'warrior_detail' nav_warrior_arena.id %}">
@@ -35,9 +33,7 @@
               </a>
             </li>
             <li>
-              {% if warrior_next_battle_url %}
-                <a href="{{ warrior_next_battle_url }}">Newer battle of {{ nav_warrior_arena }} ↷</a>
-              {% endif %}
+              <a href="{{ warrior_next_battle_url }}">Newer battle of {{ nav_warrior_arena }} ↷</a>
             </li>
           </ul>
         </nav>
@@ -45,14 +41,10 @@
       <nav aria-label="Battles in this arena">
         <ul>
           <li>
-            {% if arena_previous_battle_url %}
-              <a href="{{ arena_previous_battle_url }}">↶ Older battle in this arena</a>
-            {% endif %}
+            <a href="{{ arena_previous_battle_url }}">↶ Older battle in this arena</a>
           </li>
           <li>
-            {% if arena_next_battle_url %}
-              <a href="{{ arena_next_battle_url }}">Newer battle in this arena ↷</a>
-            {% endif %}
+            <a href="{{ arena_next_battle_url }}">Newer battle in this arena ↷</a>
           </li>
         </ul>
       </nav>

--- a/warriors/tests/test_views.py
+++ b/warriors/tests/test_views.py
@@ -223,46 +223,72 @@ def schedule_in_order(*battles):
         battle.save(update_fields=['scheduled_at'])
 
 
-def battle_url(battle, warrior_arena=None):
-    url = reverse('battle_detail', args=(battle.id,))
+def battle_url(url_name, battle, warrior_arena=None):
+    url = reverse(url_name, args=(battle.id,))
     if warrior_arena is not None:
         url += f'?warrior_arena={warrior_arena.id}'
     return url
 
 
 @pytest.mark.django_db
-def test_battle_details_nav_walks_both(client, arena, warrior_arena):
+@pytest.mark.parametrize('scoped', [True, False])
+def test_battle_details_nav_links(client, arena, warrior_arena, scoped):
+    """
+    The page links its walks without walking them.
+
+    This battle has no neighbour either way,
+    and the links are there anyway;
+    the warrior walk appears only once a warrior is named.
+    """
+    battle, = batch_create_battles(arena, warrior_arena, 1)
+    nav_warrior = warrior_arena if scoped else None
+
+    response = client.get(battle_url('battle_detail', battle, nav_warrior))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert battle_url('previous_arena_battle', battle, nav_warrior) in content
+    assert battle_url('next_arena_battle', battle, nav_warrior) in content
+    assert (battle_url('previous_warrior_battle', battle, nav_warrior) in content) is scoped
+    assert (battle_url('next_warrior_battle', battle, nav_warrior) in content) is scoped
+
+
+@pytest.mark.django_db
+def test_battle_nav_walks_both(client, arena, warrior_arena):
     """A battle of other warriors is the arena's next one and not the warrior's."""
     older, middle, newer = batch_create_battles(arena, warrior_arena, 3)
     stranger = batch_create_battles(arena, WarriorArenaFactory(arena=arena), 1)[0]
     schedule_in_order(older, middle, stranger, newer)
 
-    response = client.get(battle_url(middle, warrior_arena))
+    def step(url_name):
+        return client.get(battle_url(url_name, middle, warrior_arena))['Location']
 
-    assert response.status_code == 200
-    assert response.context['arena_previous_battle_url'] == battle_url(older, warrior_arena)
-    assert response.context['arena_next_battle_url'] == battle_url(stranger, warrior_arena)
-    assert response.context['warrior_previous_battle_url'] == battle_url(older, warrior_arena)
-    assert response.context['warrior_next_battle_url'] == battle_url(newer, warrior_arena)
-    # both walks reach the page, not just the context
-    content = response.content.decode()
-    assert battle_url(stranger, warrior_arena) in content
-    assert battle_url(newer, warrior_arena) in content
+    assert step('previous_arena_battle') == battle_url('battle_detail', older, warrior_arena)
+    assert step('next_arena_battle') == battle_url('battle_detail', stranger, warrior_arena)
+    assert step('previous_warrior_battle') == battle_url('battle_detail', older, warrior_arena)
+    assert step('next_warrior_battle') == battle_url('battle_detail', newer, warrior_arena)
 
 
 @pytest.mark.django_db
-def test_battle_details_nav_without_a_warrior(client, arena, warrior_arena):
-    """Naming no warrior leaves the arena walk, so the battle URL stands alone."""
+def test_battle_nav_without_a_warrior(client, arena, warrior_arena):
+    """Naming no warrior leaves the arena walk, and leaves the warrior walk nothing to step through."""
     older, middle, newer = batch_create_battles(arena, warrior_arena, 3)
     schedule_in_order(older, middle, newer)
 
-    response = client.get(battle_url(middle))
+    response = client.get(battle_url('previous_arena_battle', middle))
+    assert response['Location'] == battle_url('battle_detail', older)
 
-    assert response.status_code == 200
-    assert response.context['arena_previous_battle_url'] == battle_url(older)
-    assert response.context['arena_next_battle_url'] == battle_url(newer)
-    assert response.context['warrior_previous_battle_url'] is None
-    assert response.context['warrior_next_battle_url'] is None
+    response = client.get(battle_url('previous_warrior_battle', middle))
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('url_name', ['previous_arena_battle', 'next_warrior_battle'])
+def test_battle_nav_end_of_walk(client, arena, warrior_arena, url_name):
+    """A walk with nowhere left to go ends here, since the link could not say so."""
+    battle, = batch_create_battles(arena, warrior_arena, 1)
+    response = client.get(battle_url(url_name, battle, warrior_arena))
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -288,7 +314,7 @@ def test_warrior_details_links_carry_the_warrior(client, warrior_arena, battle):
     response = client.get(
         reverse('warrior_detail', args=(warrior_arena.id,))
     )
-    assert battle_url(battle, warrior_arena) in response.content.decode()
+    assert battle_url('battle_detail', battle, warrior_arena) in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/warriors/views.py
+++ b/warriors/views.py
@@ -1,9 +1,11 @@
 import uuid
+from typing import NamedTuple
 
 from django import forms
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -238,35 +240,36 @@ class BattleDetailView(DetailView):
         self.object.game_2_1.show_secrets_2 = show_secrets_1
         self.object.game_2_1.show_battle_results = show_battle_results
 
-        warrior_arena = self.get_nav_warrior_arena()
+        warrior_arena = get_nav_warrior_arena(self.request, self.object)
         context['nav_warrior_arena'] = warrior_arena
-        context.update(battle_nav_context(self.object, warrior_arena, self.request.user))
+        context.update(battle_nav_context(self.object, warrior_arena))
 
         return context
 
-    def get_nav_warrior_arena(self):
-        """
-        The warrior named by the `warrior_arena` query parameter, if it fought here.
 
-        The warrior page puts the parameter on every link into a battle,
-        so that stepping onward from there stays in the list it showed.
-        A value naming no warrior of this battle names no warrior at all.
-        """
-        try:
-            warrior_arena_id = uuid.UUID(self.request.GET.get('warrior_arena', ''))
-        except ValueError:
-            return None
-        warrior_arena = WarriorArena.objects.filter(
-            id=warrior_arena_id,
-        ).select_related('arena').first()
-        if warrior_arena is None:
-            return None
-        if warrior_arena.warrior_id not in (self.object.warrior_1_id, self.object.warrior_2_id):
-            return None
-        return warrior_arena
+def get_nav_warrior_arena(request, battle):
+    """
+    The warrior named by the `warrior_arena` query parameter, if it fought here.
+
+    The warrior page puts the parameter on every link into a battle,
+    so that stepping onward from there stays in the list it showed.
+    A value naming no warrior of this battle names no warrior at all.
+    """
+    try:
+        warrior_arena_id = uuid.UUID(request.GET.get('warrior_arena', ''))
+    except ValueError:
+        return None
+    warrior_arena = WarriorArena.objects.filter(
+        id=warrior_arena_id,
+    ).select_related('arena').first()
+    if warrior_arena is None:
+        return None
+    if warrior_arena.warrior_id not in (battle.warrior_1_id, battle.warrior_2_id):
+        return None
+    return warrior_arena
 
 
-def battle_nav_context(battle, warrior_arena, user):
+def battle_nav_context(battle, warrior_arena):
     """
     Links for the two walks through neighbouring battles in time.
 
@@ -275,39 +278,85 @@ def battle_nav_context(battle, warrior_arena, user):
     stepping through the list `WarriorDetailView` shows.
     Both carry the warrior onward,
     so an arena step landing on another of its battles keeps the warrior walk.
+
+    Each link addresses `battle_nav`, which is where a step is resolved,
+    so offering four of them costs four `reverse` calls and no query.
     """
-    arena_previous, arena_next = battle_neighbour_urls(
-        Battle.objects.for_user(user).filter(arena__llm=battle.llm),
-        battle, warrior_arena,
-    )
-    if warrior_arena is None:
-        warrior_previous, warrior_next = None, None
-    else:
-        warrior_previous, warrior_next = battle_neighbour_urls(
-            Battle.objects.with_warrior_arena(warrior_arena),
-            battle, warrior_arena,
-        )
-    return {
-        'arena_previous_battle_url': arena_previous,
-        'arena_next_battle_url': arena_next,
-        'warrior_previous_battle_url': warrior_previous,
-        'warrior_next_battle_url': warrior_next,
+    context = {
+        'arena_previous_battle_url': battle_url('previous_arena_battle', battle, warrior_arena),
+        'arena_next_battle_url': battle_url('next_arena_battle', battle, warrior_arena),
+        'warrior_previous_battle_url': None,
+        'warrior_next_battle_url': None,
     }
+    if warrior_arena is not None:
+        context['warrior_previous_battle_url'] = battle_url('previous_warrior_battle', battle, warrior_arena)
+        context['warrior_next_battle_url'] = battle_url('next_warrior_battle', battle, warrior_arena)
+    return context
 
 
-def battle_neighbour_urls(battles, battle, warrior_arena):
-    """Links to the battles either side of this one within `battles`, older first."""
-    battles = battles.only('id', 'scheduled_at')
-    older = battles.filter(scheduled_at__lt=battle.scheduled_at).order_by('-scheduled_at').first()
-    newer = battles.filter(scheduled_at__gt=battle.scheduled_at).order_by('scheduled_at').first()
-    return battle_url(older, warrior_arena), battle_url(newer, warrior_arena)
+class TimeDirection(NamedTuple):
+    """
+    One side of a battle in time: previous is earlier, next is later.
+
+    `side` keeps the battles lying that way,
+    and `nearest_first` orders them so the closest one comes first.
+    """
+    side: str
+    nearest_first: str
 
 
-def battle_url(battle, warrior_arena):
+PREVIOUS = TimeDirection('scheduled_at__lt', '-scheduled_at')
+NEXT = TimeDirection('scheduled_at__gt', 'scheduled_at')
+
+
+def previous_arena_battle(request, pk):
+    return battle_nav(request, pk, PREVIOUS, warrior_walk=False)
+
+
+def next_arena_battle(request, pk):
+    return battle_nav(request, pk, NEXT, warrior_walk=False)
+
+
+def previous_warrior_battle(request, pk):
+    return battle_nav(request, pk, PREVIOUS, warrior_walk=True)
+
+
+def next_warrior_battle(request, pk):
+    return battle_nav(request, pk, NEXT, warrior_walk=True)
+
+
+def battle_nav(request, pk, direction, warrior_walk):
+    """
+    Redirect to the neighbour one step of one walk lands on.
+
+    The battle page links here rather than resolving four neighbours
+    on every render, for steps most of its visitors never take.
+    The price is a link offered before anything looked for its target:
+    a walk out of battles ends in a 404 here, not in an absent link.
+
+    The two walks are the ones `battle_nav_context` offers,
+    and a warrior step is only a step while the warrior is still named —
+    the parameter is what says which list is being walked.
+    """
+    battle = get_object_or_404(Battle, pk=pk)
+    warrior_arena = get_nav_warrior_arena(request, battle)
+    if warrior_walk:
+        if warrior_arena is None:
+            raise Http404('This walk needs a warrior that fought here')
+        battles = Battle.objects.with_warrior_arena(warrior_arena)
+    else:
+        battles = Battle.objects.for_user(request.user).filter(arena__llm=battle.llm)
+    neighbour = battles.only('id', 'scheduled_at').filter(
+        **{direction.side: battle.scheduled_at},
+    ).order_by(direction.nearest_first).first()
+    if neighbour is None:
+        raise Http404('The walk ends here')
+    return redirect(battle_url('battle_detail', neighbour, warrior_arena))
+
+
+def battle_url(url_name, battle, warrior_arena):
     """A battle link that keeps the warrior whose list it was reached from, if any."""
-    if battle is None:
-        return None
-    url = reverse('battle_detail', args=(battle.id,))
+    url = reverse(url_name, args=(battle.id,))
     if warrior_arena is not None:
         url += '?' + urlencode({'warrior_arena': warrior_arena.id})
     return url


### PR DESCRIPTION
Closes #7. Rebased onto `main` after the two-walk nav landed, and rebuilt on that shape.

The battle page resolved four neighbours on every render — two ordered scans per walk, arena and warrior — for steps most visitors never take. Each link now addresses a redirect view that runs its scan when someone clicks it.

- Four routes over one `battle_nav`: `battle/<pk>/{arena,warrior}/{previous,next}/`. It finds the nearest battle on its side of `scheduled_at` within its walk and redirects there, carrying the `warrior_arena` parameter onward.
- `battle_nav_context` keeps its four context keys and its shape; it now fills them with `reverse()` calls and runs no query.
- A warrior step 404s without a warrior parameter naming a warrior that fought in the battle — that parameter is what says which list is being walked, so a step without it has no list.
- `get_nav_warrior_arena` moved off `BattleDetailView` to a module function, since both the page and the redirect validate the parameter the same way.

Where each walk lands is unchanged: both querysets moved across as they were.

## The visible tradeoff

Nothing has looked for a neighbour by the time the page renders, so every link is drawn, and clicking one at the end of a walk gives a 404 instead of the link simply being absent. That is inherent to deferring the scan; `battle_nav`'s docstring says so at the source. If the absent link is worth keeping, the middle ground is an `.exists()` check per link — four indexed queries instead of four row fetches — which is not what this branch does.

`TODO.md`: the `for_user` / `arena__llm` entry now names `battle_nav`, and its last line is restated — under lazy links that narrowing turns a signed-in visitor's step off a stranger's battle into a 404 rather than a page rendered without neighbours. The behavior change it proposes still awaits sign-off. The `warrior_arena`-in-three-places entry needed only its reference to `get_nav_warrior_arena` updated.

## Testing

`test_battle_details_nav_links` renders a battle with no neighbour in either walk and asserts the links are in the page anyway, with the warrior pair appearing only when a warrior is named — the observable shape of linking a walk without walking it. `test_battle_nav_walks_both` carries over the four-way assertion from the page test to the redirects: a stranger's battle is the arena's next one and not the warrior's. `test_battle_nav_without_a_warrior` covers the arena walk standing alone and the warrior walk 404ing, and `test_battle_nav_end_of_walk` the ends.

`warriors/` suite: 145 passed, 3 deselected (`real_world`). `flake8`, `pylint`, and `makemigrations --check` clean.
