### PR TITLE
Walk the arena and one warrior side by side

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -227,8 +227,8 @@ its recompute-from-bodies logic moves into
 the game-row sha repair command (see the `input_sha256` entry),
 and the script goes.
 
-The arena-wide half of `battle_nav_urls` (`warriors/views.py`)
-picks its battles two ways the warrior-scoped half does not.
+The arena walk in `battle_nav_context` (`warriors/views.py`)
+picks its battles two ways the warrior walk beside it does not.
 It joins `arena__llm` where `llm` is a column on the battle itself,
 and `Battle.arena` is nullable,
 so a battle with no arena drops out of the walk silently.
@@ -237,6 +237,20 @@ which narrows a signed-in visitor to battles of their own warriors:
 the same page then offers different neighbours to different people,
 and often none at all to someone reading a stranger's battle,
 while an anonymous visitor walks everything.
+Now that the arena walk is the one nav every battle page carries,
+that is the difference between a page with neighbours and a dead end.
 Next move: filter `llm=battle.llm` directly and drop the `for_user` call,
-leaving both halves scoped by nothing but what is being browsed.
+leaving both walks scoped by nothing but what is being browsed.
 Both are behavior changes, so they need sign-off.
+
+The `warrior_arena` query parameter that carries a warrior into a battle page
+is spelled out in three places that must agree:
+`battle_url` builds it (`warriors/views.py`),
+`BattleDetailView.get_nav_warrior_arena` reads it,
+and `warriorarena_detail.html` hand-writes
+`?warrior_arena={{ warrior.id }}` onto four links.
+Rename the parameter and the template links keep pointing at the old name,
+silently losing the warrior walk rather than failing.
+Next move: expose `battle_url` as a template tag
+and call it from those four links,
+leaving the parameter named once on each side of the request.

--- a/templates/warriors/battle_detail.html
+++ b/templates/warriors/battle_detail.html
@@ -21,23 +21,37 @@
     </section>
 
     <section>
-      <nav>
-        <ul>
-          <li>
-            {% if previous_battle_url %}
-              <a href="{{ previous_battle_url }}">↶ Older battle</a>
-            {% endif %}
-          </li>
-          {% if nav_warrior_arena %}
+      {% if nav_warrior_arena %}
+        <nav aria-label="Battles of {{ nav_warrior_arena }}">
+          <ul>
+            <li>
+              {% if warrior_previous_battle_url %}
+                <a href="{{ warrior_previous_battle_url }}">↶ Older battle of {{ nav_warrior_arena }}</a>
+              {% endif %}
+            </li>
             <li>
               <a href="{% url 'warrior_detail' nav_warrior_arena.id %}">
                 All battles of {{ nav_warrior_arena }}
               </a>
             </li>
-          {% endif %}
+            <li>
+              {% if warrior_next_battle_url %}
+                <a href="{{ warrior_next_battle_url }}">Newer battle of {{ nav_warrior_arena }} ↷</a>
+              {% endif %}
+            </li>
+          </ul>
+        </nav>
+      {% endif %}
+      <nav aria-label="Battles in this arena">
+        <ul>
           <li>
-            {% if next_battle_url %}
-              <a href="{{ next_battle_url }}">Newer battle ↷</a>
+            {% if arena_previous_battle_url %}
+              <a href="{{ arena_previous_battle_url }}">↶ Older battle in this arena</a>
+            {% endif %}
+          </li>
+          <li>
+            {% if arena_next_battle_url %}
+              <a href="{{ arena_next_battle_url }}">Newer battle in this arena ↷</a>
             {% endif %}
           </li>
         </ul>

--- a/warriors/tests/test_views.py
+++ b/warriors/tests/test_views.py
@@ -231,22 +231,38 @@ def battle_url(battle, warrior_arena=None):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('scoped', [True, False])
-def test_battle_details_nav(client, arena, warrior_arena, scoped):
-    """The warrior parameter is what keeps a stranger's battle out of the walk."""
+def test_battle_details_nav_walks_both(client, arena, warrior_arena):
+    """A battle of other warriors is the arena's next one and not the warrior's."""
     older, middle, newer = batch_create_battles(arena, warrior_arena, 3)
     stranger = batch_create_battles(arena, WarriorArenaFactory(arena=arena), 1)[0]
     schedule_in_order(older, middle, stranger, newer)
 
-    nav_warrior = warrior_arena if scoped else None
-    response = client.get(battle_url(middle, nav_warrior))
+    response = client.get(battle_url(middle, warrior_arena))
 
     assert response.status_code == 200
-    assert response.context['nav_warrior_arena'] == nav_warrior
-    assert response.context['previous_battle_url'] == battle_url(older, nav_warrior)
-    assert response.context['next_battle_url'] == battle_url(
-        newer if scoped else stranger, nav_warrior,
-    )
+    assert response.context['arena_previous_battle_url'] == battle_url(older, warrior_arena)
+    assert response.context['arena_next_battle_url'] == battle_url(stranger, warrior_arena)
+    assert response.context['warrior_previous_battle_url'] == battle_url(older, warrior_arena)
+    assert response.context['warrior_next_battle_url'] == battle_url(newer, warrior_arena)
+    # both walks reach the page, not just the context
+    content = response.content.decode()
+    assert battle_url(stranger, warrior_arena) in content
+    assert battle_url(newer, warrior_arena) in content
+
+
+@pytest.mark.django_db
+def test_battle_details_nav_without_a_warrior(client, arena, warrior_arena):
+    """Naming no warrior leaves the arena walk, so the battle URL stands alone."""
+    older, middle, newer = batch_create_battles(arena, warrior_arena, 3)
+    schedule_in_order(older, middle, newer)
+
+    response = client.get(battle_url(middle))
+
+    assert response.status_code == 200
+    assert response.context['arena_previous_battle_url'] == battle_url(older)
+    assert response.context['arena_next_battle_url'] == battle_url(newer)
+    assert response.context['warrior_previous_battle_url'] is None
+    assert response.context['warrior_next_battle_url'] is None
 
 
 @pytest.mark.django_db

--- a/warriors/views.py
+++ b/warriors/views.py
@@ -240,9 +240,7 @@ class BattleDetailView(DetailView):
 
         warrior_arena = self.get_nav_warrior_arena()
         context['nav_warrior_arena'] = warrior_arena
-        context['previous_battle_url'], context['next_battle_url'] = battle_nav_urls(
-            self.object, warrior_arena, self.request.user,
-        )
+        context.update(battle_nav_context(self.object, warrior_arena, self.request.user))
 
         return context
 
@@ -268,29 +266,48 @@ class BattleDetailView(DetailView):
         return warrior_arena
 
 
-def battle_nav_urls(battle, warrior_arena, user):
+def battle_nav_context(battle, warrior_arena, user):
     """
-    Links to the battles either side of this one in time, older first.
+    Links for the two walks through neighbouring battles in time.
 
-    Given a warrior, they walk that warrior's battles —
-    the list `WarriorDetailView` shows, so the two pages agree on
-    what comes next — and carry the warrior onward.
-    Without one they walk the arena, and the battle URL stands alone.
+    The arena walk is always offered, being all a battle URL supplies on its own;
+    the warrior walk joins it once a warrior is named,
+    stepping through the list `WarriorDetailView` shows.
+    Both carry the warrior onward,
+    so an arena step landing on another of its battles keeps the warrior walk.
     """
+    arena_previous, arena_next = battle_neighbour_urls(
+        Battle.objects.for_user(user).filter(arena__llm=battle.llm),
+        battle, warrior_arena,
+    )
     if warrior_arena is None:
-        battles = Battle.objects.for_user(user).filter(arena__llm=battle.llm)
+        warrior_previous, warrior_next = None, None
     else:
-        battles = Battle.objects.with_warrior_arena(warrior_arena)
+        warrior_previous, warrior_next = battle_neighbour_urls(
+            Battle.objects.with_warrior_arena(warrior_arena),
+            battle, warrior_arena,
+        )
+    return {
+        'arena_previous_battle_url': arena_previous,
+        'arena_next_battle_url': arena_next,
+        'warrior_previous_battle_url': warrior_previous,
+        'warrior_next_battle_url': warrior_next,
+    }
+
+
+def battle_neighbour_urls(battles, battle, warrior_arena):
+    """Links to the battles either side of this one within `battles`, older first."""
     battles = battles.only('id', 'scheduled_at')
     older = battles.filter(scheduled_at__lt=battle.scheduled_at).order_by('-scheduled_at').first()
     newer = battles.filter(scheduled_at__gt=battle.scheduled_at).order_by('scheduled_at').first()
-    return battle_nav_url(older, warrior_arena), battle_nav_url(newer, warrior_arena)
+    return battle_url(older, warrior_arena), battle_url(newer, warrior_arena)
 
 
-def battle_nav_url(neighbour, warrior_arena):
-    if neighbour is None:
+def battle_url(battle, warrior_arena):
+    """A battle link that keeps the warrior whose list it was reached from, if any."""
+    if battle is None:
         return None
-    url = reverse('battle_detail', args=(neighbour.id,))
+    url = reverse('battle_detail', args=(battle.id,))
     if warrior_arena is not None:
         url += '?' + urlencode({'warrior_arena': warrior_arena.id})
     return url


### PR DESCRIPTION
Scoping prev/next to a warrior (227a99b) made the two walks exclusive:
arriving from a warrior page gave up the arena-wide walk,
and getting it back meant editing the query string by hand.
This restores the global walk alongside the warrior-local one.

## What changed

`battle_nav_urls` returns both walks instead of choosing between them:

- **Arena walk** — always computed, as `arena_previous_battle_url` / `arena_next_battle_url`.
  Same queryset the global nav used before 227a99b,
  so a battle URL that names no warrior still has neighbours.
- **Warrior walk** — `warrior_previous_battle_url` / `warrior_next_battle_url`,
  populated only when `?warrior_arena=` names a warrior that fought in the battle.

Both sets of links carry the warrior onward,
so an arena step that happens to land on another of that warrior's battles
keeps the warrior walk;
one that lands elsewhere drops it,
since `get_nav_warrior_arena` only recognizes a participant.

`battle_detail.html` renders the warrior nav (with the "All battles of X" link)
above the arena nav,
labelling the warrior-scoped links by warrior name
so the two rows aren't ambiguous when both show.

## Tests

`test_battle_details_nav` asserts all four URLs in both the scoped and unscoped cases —
notably that the arena walk crosses into a stranger's battle
while the warrior walk skips it.
`warriors/` is green (141 passed, `real_world` deselected), flake8 clean.

## Needs a decision, left alone

The `TODO.md` entry 227a99b logged is now more consequential, so its wording is updated
but not the behavior it describes.
The arena walk runs through `for_user`,
which narrows a signed-in visitor to battles of their own warriors.
That used to affect only people who reached a battle without a warrior parameter;
now the arena walk is on every battle page,
so a signed-in visitor reading a stranger's battle gets a nav with no links at all
where an anonymous visitor gets neighbours.
The fix is two lines — filter `llm=battle.llm` directly, drop the `for_user` call —
but it is a visible behavior change that the TODO entry says needs sign-off,
so it is not in this PR.

## Overlaps with #61

#61 reworks the same `battle_nav_urls` code
(moving neighbour resolution behind a redirect view),
so these two will conflict.
Whichever lands second should be rebased onto the other;
the two changes are independent in intent
and the resolution is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEBT5VhAcQeDnMyFW5qJvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEBT5VhAcQeDnMyFW5qJvf)_