### PR TITLE
Read the game as a microblog, then prune the reframe

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -110,6 +110,14 @@ live in [docs/strategy.md](docs/strategy.md);
 design-level strengths, tensions, and candidate directions
 in [docs/design-tensions.md](docs/design-tensions.md);
 the fixed-cadence rounds proposal in [docs/rounds.md](docs/rounds.md);
+the microblog reading of the same mechanics
+in [docs/twitter-for-prompts.md](docs/twitter-for-prompts.md);
+prior art for the mechanics this project keeps proposing —
+audience-as-fitness, lineage, blending, generated feeds —
+in [docs/precedents.md](docs/precedents.md);
+the doctrinal gap around blended outputs,
+used as a novelty detector,
+in [docs/authorship.md](docs/authorship.md);
 the gameplay data model's coupling analysis and target shape
 in [docs/data-model.md](docs/data-model.md);
 this doc stays about the game's concept and mechanics.

--- a/docs/authorship.md
+++ b/docs/authorship.md
@@ -1,0 +1,134 @@
+# Authorship of a blend
+
+Law used as an instrument, not an obligation.
+Doctrine is a map of configurations people have already had to settle;
+where it has no mechanic,
+the object in front of you is probably new.
+Battle outputs sit in such a hole,
+and the hole is specific enough to name —
+which makes it a sharper claim of originality
+than "Core War for LLMs".
+
+## The configuration
+
+Four properties at once:
+
+1. two humans contributed expression;
+2. neither consented to collaborate — each tried to erase the other;
+3. a machine performed the combination;
+4. how much of each contribution survived is measured and recorded
+   (per direction and per algorithm, in `warriors/score.py`).
+
+Property 4 is the rare one.
+Property 2 is the one that breaks the doctrine
+built for two-contributor works.
+And because outputs are valid inputs,
+shares compound across generations
+(`docs/lineages.md`).
+
+## Three doctrines, three answers, no tiebreaker
+
+**Copyright authorship: nobody.**
+Human authorship is required,
+and for the purpose of authoring the *output*
+prompts are treated as instructions conveying unprotectable ideas
+([US Copyright Office, Part 2, 2025](https://www.dlapiper.com/en-us/insights/publications/2025/03/copyrightability-of-genai-outputs-in-the-us-key-developments));
+the human-authorship requirement was affirmed in
+[Thaler v. Perlmutter](https://media.cadc.uscourts.gov/opinions/docs/2025/03/23-5233.pdf)
+with
+[review denied](https://www.mayerbrown.com/en/insights/publications/2026/03/supreme-court-denies-review-in-ai-authorship-case).
+EU law reaches the same place from originality:
+no author's own intellectual creation, no protection
+([EPRS overview](https://www.europarl.europa.eu/thinktank/en/document/EPRS_BRI(2025)782585)).
+So the blend is an authorless artifact
+with two identifiable contributors.
+
+**Joint authorship: not applicable, by construction.**
+A joint work requires the contributors to intend
+that their contributions merge into a unitary whole
+([Childress v. Taylor](https://law.justia.com/cases/federal/appellate-courts/F2/945/500/289853/)).
+Players intend the opposite.
+The one doctrine designed for two-contributor works
+is excluded by the game's central mechanic,
+and the leading framework for machine-assisted authorship
+([Ginsburg and Budiardjo](https://btlj.org/data/articles2019/34_2/01_Ginsburg_Web.pdf))
+analyses one human and a machine, not two humans in opposition.
+
+**Contract: the operator.**
+Model providers assign output rights to the API customer
+([OpenAI](https://openai.com/policies/row-terms-of-use/),
+[Gemini](https://ai.google.dev/gemini-api/terms)) —
+here, the party that wrote none of it.
+The two people who did write it are not parties to that assignment.
+
+Contract says the operator,
+copyright says nobody,
+joint authorship declines the question,
+and none of the three looks at the measured shares.
+That is the gap.
+
+## Why this is worth writing down
+
+**It names what is actually novel.**
+Not "AI mixes text" —
+*measured, non-consensual, multi-author derivation,
+recursively.*
+
+**It gives the corpus a second market.**
+`docs/strategy.md` treats the dataset as downside protection
+for prompt-injection research.
+This is a distinct claim on the same rows:
+courts decline to quantify how much of a work survives into another,
+and here that quantity exists by construction,
+for hundreds of thousands of two-contributor artifacts with provenance.
+An empirical instrument for a question doctrine avoids
+is worth a writeup on its own.
+
+**It converts attribution from compliance into design.**
+There is no legal default to inherit,
+so who gets the byline,
+who may ask for a blend to be removed,
+and what a repost carries
+are all decisions.
+`docs/twitter-for-prompts.md` takes the stance —
+byline to the two writers, model as medium —
+and the absence of doctrine is what makes that a stance
+rather than a formality.
+
+## Dead ends
+
+**"Are we allowed to?"**
+At this scale the compliance question decides nothing
+the harassment evidence in `docs/precedents.md` does not already decide.
+
+**Claiming operator ownership because the provider terms permit it.**
+Cheap, and it contradicts the attribution stance,
+which is the asset.
+
+**Waiting for the law to settle before designing attribution.**
+There is nothing to wait for:
+the object precedes the doctrine.
+
+**Treating prompts as owned property** —
+licensing, exclusivity, infringement claims between players.
+Whether a given warrior is protectable expression
+is a separate question from the output-authorship one above
+and turns on length and originality,
+so it has no single answer across the corpus.
+A game whose mechanic is copying each other's text
+has nothing to gain from asking.
+
+## Open
+
+Is an output a derivative of the two prompts, a compilation, or nothing?
+The similarity scores argue for the first;
+the authorship doctrine points at the third.
+
+Does the re-submission loop compound contribution shares
+across generations,
+and is there any framework that tracks that?
+Nothing found does.
+
+Cheapest test of the second-market claim:
+show the measured-share corpus to one copyright scholar
+and see whether the reaction is "so what" or "nobody has this".

--- a/docs/design-tensions.md
+++ b/docs/design-tensions.md
@@ -83,14 +83,21 @@ with no way even to watch a rival.
 
 ## Directions, ranked by leverage
 
-1. **Novelty surfacing.**
-   Rank outputs by embedding distance from the existing corpus;
-   surface a feed of notable battles.
+1. **Novelty surfacing, as a shortlist rather than a feed.**
+   Rank outputs by embedding distance from the existing corpus,
+   and use the ranking to narrow a period's outputs
+   to a handful a person then picks and sequences.
    This attacks the buried-gems problem
    with data the system pays for anyway,
-   and provides the content engine
-   for the digest email and the shareable meta-report
+   and produces the digest email and shareable meta-report
    in `docs/strategy.md`.
+   Ranking alone is not an editor:
+   every comparable system that worked was curated by a human,
+   and the uncurated ones failed (`docs/precedents.md`).
+   Embedding novelty is also much harder to goodhart
+   than an LLM interestingness judge,
+   which players would hijack immediately
+   (the data–instruction separation theme in `docs/parallels.md`).
 2. **Adopt-an-output.**
    One click turns a battle result into a warrior.
    This makes the competition-creation duality
@@ -101,13 +108,14 @@ with no way even to watch a rival.
    Adoption count is also a fame metric that rewards generativity:
    "my warrior's children are everywhere"
    points the opposite way from sterile dominance.
-3. **A second leaderboard axis.**
-   Keep the dominance rating untouched;
-   add a parallel ranking fed by output novelty and adoption counts.
-   Embedding-based novelty is much harder to goodhart
-   than an LLM interestingness judge,
-   which players would hijack immediately
-   (the data–instruction separation theme in `docs/parallels.md`).
+3. **A second leaderboard axis — rejected at this scale.**
+   A parallel ranking fed by novelty and adoption counts
+   is ranking machinery aimed at single-digit monthly actives,
+   and a board nobody reads changes no behavior.
+   Compute both signals anyway,
+   as inputs to the shortlist in direction 1
+   and as the fame metrics attached to a warrior's page.
+   Revisit when there is a population to rank.
 4. **A cooperative mode.**
    Two strangers' prompts scored on fusion quality
    (`cooperation_score`) instead of dominance —
@@ -123,3 +131,9 @@ Novelty (embeddings),
 lineage (players copy-paste battle results by hand),
 and cooperation (scored but hidden)
 all exist with no surface and no consequence.
+`docs/twitter-for-prompts.md` reads the first two directions
+as one product framing —
+the game as a microblog whose publishing step is the model —
+and prunes it to what evidence supports.
+`docs/precedents.md` holds that evidence:
+every direction above has been run somewhere else.

--- a/docs/lineages.md
+++ b/docs/lineages.md
@@ -35,3 +35,15 @@ The system recognizes that:
 3. Only battle results that catch human attention and get adopted become part of the active warrior population
 
 This creates a human-curated evolution where successful battle outputs propagate only when humans find them worthy of becoming new warriors.
+
+## The cheaper alternative: record parentage instead of inferring it
+
+Fuzzy matching is only necessary
+while adoption happens outside the system, by copy-paste.
+Picbreeder (`docs/precedents.md`)
+records parentage at the moment a user branches,
+which is exact and free;
+the adopt-an-output direction in `docs/design-tensions.md`
+is what turns copy-paste into a recorded act.
+Minhashing remains the right tool
+only for warriors already submitted by hand.

--- a/docs/precedents.md
+++ b/docs/precedents.md
@@ -1,0 +1,118 @@
+# Prior art
+
+Systems that already ran the pieces this project keeps proposing.
+One entry each, ending in what transfers.
+The arguments built on them:
+`docs/twitter-for-prompts.md` (microblog reframe),
+`docs/design-tensions.md` (novelty, adoption),
+`docs/lineages.md` (ancestry),
+`docs/rounds.md` (cadence).
+
+**The mechanic is unoccupied.**
+Nothing found publishes a machine blend
+of two strangers' unprompted writing.
+Adjacent: AI as the audience for a post,
+AI combining two chosen inputs,
+humans garbling each other in party games,
+players attacking a model.
+Weak evidence from few searches,
+but there is no template to copy and no obituary to read.
+
+**[Electric Sheep](https://en.wikipedia.org/wiki/Electric_Sheep)**
+(Draves, from 1999) evolves fractal-flame animations
+from arrow-key votes cast by screensaver viewers;
+popular sheep are crossed and mutated, unpopular ones die,
+and human "shepherds" steer the mating.
+Transfers: fitness can come from spectators
+at one keystroke with no account and nothing authored,
+and a human hand on the tiller is part of the form.
+
+**[Picbreeder](https://direct.mit.edu/evco/article/19/3/373/1371/Picbreeder-A-Case-Study-in-Collaborative)**
+(2007–2021) let users continue evolving other users' published images.
+Publishing was deliberate; branching recorded parentage at the branch.
+Transfers: lineage recorded at adoption is exact and free.
+
+**Quality-diversity search** defines the shortlist metric:
+novelty as mean distance to the *k* nearest neighbors in an archive
+([survey](https://arxiv.org/pdf/1708.09251)) —
+computable on stored embeddings.
+Its central claim, that optimizing novelty preserves
+what optimizing fitness destroys,
+is the central tension in `docs/design-tensions.md`
+reached from the other side.
+
+**[Infinite Craft](https://en.wikipedia.org/wiki/Infinite_Craft)**
+(2024) went viral on two-input blending
+with no opponent, rating, or leaderboard —
+the reward is First Discovery credit for an untried pair.
+Transfers: credit-for-novelty motivates this exact mechanical shape.
+
+**[Emoji Kitchen](https://emojipedia.org/emoji-kitchen)**
+is the most-loved two-input blend in consumer software,
+and every combination is hand-drawn.
+Warns: the median automatic blend is mush;
+a blending product lives in the tail.
+
+**Telephone games**
+([Gartic Phone](https://en.wikipedia.org/wiki/Gartic_Phone)
+and the exquisite-corpse lineage)
+prove distortion-through-relay generates delight —
+at the *reveal*, in a group, over a short chain.
+This game has the distortion and no reveal,
+which is what `docs/rounds.md` reaches for.
+
+**[Renga](https://en.wikipedia.org/wiki/Renku)**
+formalized fusion quality centuries ago:
+a verse must link to the previous and shift away from it,
+and the sōshō may reject a verse.
+Transfers: link-and-shift is the pair of axes
+`cooperation_score` in `warriors/score.py` measures,
+and a curator with veto power is a feature of the form.
+
+**[Sora's app and Meta's Vibes](https://www.cnn.com/2025/10/11/tech/openai-sora-2-meta-ai-slop-social-media)**
+(2025) tested endless generated content as a feed:
+mass launch, "AI slop" reception, steep decline, Sora discontinued.
+Generation volume is not a retention mechanism.
+[SocialAI](https://techcrunch.com/2024/09/17/socialai-offers-a-twitter-like-diary-where-ai-bots-respond-to-your-posts/)
+adds the contrast: an audience of bots reads as a diary.
+Here the counterpart is a real stranger,
+which has to be visible or it might as well not exist.
+
+**[PostSecret](https://www.cbsnews.com/news/postsecret-private-secrets-anonymously-shared-with-the-world/)**
+is the anonymous-stranger feed that worked:
+about twenty of a thousand weekly submissions published,
+sequenced into an arc by one person, weekly, for two decades.
+That is the cost of an editor —
+and [@horse_ebooks](https://hyperallergic.com/trompe-ltweet-the-twitter-bot-world-horse_ebooks-left-behind/),
+beloved as machine poetry and actually a person choosing posts,
+is the same lesson twice.
+
+**[Yik Yak](https://www.failory.com/cemetery/yik-yak)**
+and Secret died of harassment;
+[Whisper survived](https://www.fastcompany.com/40424834/how-whisper-survives-as-other-anonymous-social-apps-like-yik-yak-fail)
+on moderation spending its competitors refused.
+Anonymity plus a public feed has a fatal failure mode, not a shabby one.
+
+**Gandalf's analytics dashboard**
+was publicly reachable in 2023 with roughly 18 million prompts,
+some
+[containing email addresses](https://www.theregister.com/2023/09/17/gandalf_prompt_injection_game/).
+Behavioral fact regardless of the dispute over it:
+people type identifying details into a prompt box.
+The game itself reports over a million players
+against seven single-player levels and no social loop,
+which is at least evidence that progression alone draws a crowd.
+
+**[Tensor Trust](https://arxiv.org/abs/2311.01011)**
+(2023) is the nearest competitor in mechanics
+and shipped ~126k attacks and ~46k defenses as a dataset paper.
+Its durable output is the dataset and the writeup —
+the same floor the downside-protection argument
+in `docs/strategy.md` names.
+
+**AI-mediated communication research** finds an AI penalty:
+text believed to involve AI reads as less trustworthy and less authentic,
+and the effect bites hardest on readers scanning a mixed set
+and guessing which items are machine-made
+([overview](https://academic.oup.com/jcmc/article/25/1/89/5714020)).
+The design response is to make the model the medium, not the author.

--- a/docs/rounds.md
+++ b/docs/rounds.md
@@ -41,9 +41,10 @@ But a daily pile is exactly as unreadable
 as a trickle of the same size;
 the round needs an editor.
 Rounds are the cadence;
-the novelty-surfacing direction in `docs/design-tensions.md`
-is the editor;
-each is weak without the other.
+the editor is a person,
+assisted by the novelty shortlist
+in `docs/design-tensions.md`;
+cadence without editing is a pile with a timestamp.
 
 ## Hard requirement: keep the fast lane
 

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -128,6 +128,9 @@ it is a signal the system already emits and currently discards.
    A periodic "meta report" — top warriors, upsets, strategy shifts,
    generated mostly from battle data —
    posted to the communities that already know the game.
+   `docs/twitter-for-prompts.md` designs the editorial half of this:
+   what a human-picked selection of battle outputs publishes,
+   under whose byline, and what it must not publish.
    Battle permalinks with proper link previews make each post land better.
 4. **The dataset as downside protection.**
    Hundreds of thousands of adversarial prompt battles
@@ -137,6 +140,10 @@ it is a signal the system already emits and currently discards.
    This pays out even if the game never grows:
    the project's floor is "interesting dataset plus writeup",
    not "abandoned side project".
+   The same rows carry a second, unrelated claim —
+   measured per-contributor survival in a two-author machine derivation,
+   which copyright doctrine has no mechanic for
+   (`docs/authorship.md`).
 
 Nothing else lands until signups and 30-day actives move.
 In particular the side apps (`stories`, `labirynth`, `guessing`)

--- a/docs/twitter-for-prompts.md
+++ b/docs/twitter-for-prompts.md
@@ -1,0 +1,113 @@
+# Twitter for prompts: what survives the reframe
+
+Reading the game as a microblog —
+a player writes what is on their mind,
+a model blends it with a stranger's text,
+the blend is what the world sees —
+describes the existing object accurately:
+the input box already collects unprompted writing,
+the output already carries both authors,
+and the visibility flag discussed in `docs/design-tensions.md`
+is already a publish toggle wearing game vocabulary.
+
+The reframe yields three mechanics and a long list of dead ends.
+Evidence for every verdict below is in `docs/precedents.md`.
+
+## Dead
+
+**The follow graph, handles, timelines.**
+Performance metrics trade away the one unusual asset —
+two strangers fused without either performing socially
+(`docs/design-tensions.md`).
+
+**An auto-published feed of all outputs.**
+Uncurated generated feeds do not retain anyone,
+and curation ratios elsewhere run near a few percent.
+Novelty ranking is an editor's assistant, never the editor.
+
+**Flipping the existing corpus public.**
+Prompt boxes collect personal details
+because they do not read as publication.
+Prior submissions carry the contract they were made under.
+
+**A second leaderboard axis.**
+Ranking machinery aimed at a population
+of single-digit monthly actives.
+The fusion and novelty signals are worth computing
+as inputs to a shortlist, not as a board.
+
+**Directed replies as rated battles.**
+An opponent you choose is an opponent you farm;
+unrated replies carry no stakes.
+Nothing remains between those.
+
+**Preview-and-approve before publishing.**
+Filters the corpus toward what authors find flattering
+and destroys the surprise that is the product.
+
+**Per-pair caching of blends.**
+Infinite Craft's cost lever does not transfer:
+repeat pairings are rare here
+and nondeterministic fresh output is the point.
+
+**Rewording the compose box on its own.**
+"Say what's on your mind" in front of a dominance fitness function
+is bait: sincere text loses to emoji cheese and its author leaves.
+The wording only becomes honest
+downstream of a published stream ranked on fusion rather than dominance.
+
+**Presenting blends as AI content.**
+The AI penalty discounts precisely the stranger-to-stranger intimacy
+the reframe exists to expose.
+Disclose the mechanism, give the byline to the two writers.
+
+## Survives
+
+1. **A weekly human-picked selection.**
+   A handful of blends, chosen and sequenced by a person,
+   attributed to two anonymous writers.
+   No schema change and no new mode:
+   the candidate pool is battles the existing visibility flag
+   already makes public,
+   which is narrow and is the point.
+   This is also the shareable artifact
+   the meta-report priority in `docs/strategy.md` wants,
+   and the report a round would need (`docs/rounds.md`).
+2. **One-keystroke spectator reaction.**
+   No account, no authored contribution —
+   the cheapest taste signal the system has never collected.
+3. **Adopt-an-output with parentage recorded at the click.**
+   Exact and free where the reconstruction in `docs/lineages.md`
+   is neither.
+
+## Non-negotiable constraint
+
+Publication is an act:
+opt-in at composition time,
+a report path that reaches a human,
+moderation before publication rather than after.
+Anonymity plus a public feed fails fatally rather than awkwardly.
+This is what keeps the surface hobby-sized;
+a firehose would not.
+
+## The only test that matters first
+
+Build the selection page.
+It is not a new work item:
+it is the shareable-artifact priority in `docs/strategy.md`
+with an editorial design attached,
+which is the honest net effect of this whole reframe —
+one existing priority sharpened, and a list of proposals killed.
+It fails if picking a decent handful each week is a struggle —
+which would mean the corpus is the problem
+and every mechanic above it is moot.
+Nothing else gets built until that page has readers.
+
+## Open
+
+Is the artifact the blend, or the blend shown beside its two parents?
+Is the score visible in the selection at all?
+
+Note that this is the first direction with a variable cost:
+posts draw battles, and battles cost tokens
+(the fixed-fee frame in `docs/strategy.md` stops applying).


### PR DESCRIPTION
Docs only. Three new files, four cross-references.

## What this explores

The reframe: read Prompt Wars as a microblog where the model is the publishing step — a player writes what is on their mind, it gets blended with a stranger's text, and the blend is what the world sees. The framing needs no new mechanic; it renames the noun, the verb, and the surface.

Exploration produced a superset of ideas, so the second half of the branch prunes it against evidence rather than taste.

## `docs/twitter-for-prompts.md`

What survives: a weekly human-picked selection, a one-keystroke spectator signal, and adoption with parentage recorded at the click. Only the first is worth building, and it fails visibly if picking a decent handful each week is a struggle.

What is dead, recorded so it is not re-proposed: the follow graph, an auto-published feed, flipping the existing corpus public, a second leaderboard, directed rated replies, preview-and-approve, per-pair caching, and — the sharpest one — the compose-box rewording taken alone, since sincere writing in front of a dominance score is bait.

## `docs/precedents.md`

Prior art for the mechanics this project keeps proposing: audience-as-fitness (Electric Sheep), recorded lineage (Picbreeder), two-input blending (Infinite Craft, Emoji Kitchen), feeds of generated content (Sora, Vibes), anonymous stranger feeds (PostSecret, Yik Yak), fusion quality formalized centuries ago (renga), and the two neighboring prompt-injection games. Cross-referenced from the design docs so each one carries evidence instead of assertion.

Three findings changed conclusions rather than decorating them: people type personal details into prompt boxes, so publication has to be an act; every precedent that worked was curated at ratios a novelty ranking cannot reach; and the AI-penalty literature says framing blends as AI content discounts away the stranger-to-stranger intimacy the reframe exists to expose.

## `docs/authorship.md`

Doctrine used as a novelty detector rather than a compliance chore. Battle outputs have two non-consenting human contributors, a machine combination, and a recorded measure of how much of each survived. Provider contracts route output rights to the operator who wrote none of it; copyright authorship lands on nobody; joint authorship is excluded by the adversarial intent the game is built on. None of the three looks at the measured shares.

Two payoffs: a second claim on the corpus, since courts decline to quantify what this schema quantifies by construction, and attribution becomes a design stance rather than an inherited default.

---
_Generated by [Claude Code](https://claude.ai/code/session_018NZVSD4q29TsYU8sAE92tA)_