### PR TITLE
Log the viewpoint-2 score mis-join

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -114,6 +114,32 @@ the same condition that lets the column go not-null
 in step 1 of `docs/game-migration.md`,
 so the two land together.
 
+`Game.score_object` (`warriors/battles.py`) finds a score row
+by matching the facade's direction against the row's,
+but a `BattleViewpoint` rewrites field names and not lookup keys,
+so from viewpoint 2 each game reads the other game's score.
+A second error hides it:
+`BattleViewpoint.game_scores_list` wraps each row in a
+`GameScoreViewpoint` carrying the battle-level viewpoint,
+which swaps similarities already stored in game order.
+Composed, they name the right warrior in the wrong game,
+so battle scores, performance, and ratings come out correct
+and only the warrior-arena page's two per-game columns are wrong,
+each showing what belongs to the other one
+(the xfail cases of `test_game_reports_its_own_similarities`).
+Repairing either error alone inverts every viewpoint-2 battle score —
+the unmerged `fix_battle_order` branch repairs the first —
+which `test_battle_score_splits_between_viewpoints`
+and the rating tests catch.
+Next move: select the score by the game row rather than the direction
+and drop the swap in the same change.
+`GameScoreViewpoint` then wraps nothing,
+so its scoring properties move onto `GameScore`
+and `BattleViewpoint.game_scores_list` goes with it.
+No values move and no rating changes, so no sign-off,
+and it clears the last reader selecting on `GameScore.direction` —
+what step 1 of `docs/game-migration.md` waits for.
+
 Every test that builds a `Battle` has to sort the warrior pair first,
 because `BattleFactory` passes its two `SubFactory` warriors through
 in the order given and the `warrior_ordering` check constraint

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -126,6 +126,14 @@ once nothing selects by them.
 
 ### 2. Cut the remaining readers over
 
+Not before the viewpoint-2 score mis-join is fixed
+(the `Game.score_object` entry in `TODO.md`):
+hydrating a viewpoint from its game rows
+repairs one of two errors that cancel each other,
+and repairing either one alone moves every rating.
+The averaging claim in the rating bullet below
+survives this step only if both go.
+
 In order of blast radius:
 
 - **Rating** (`WarriorArena.update_rating`,

--- a/warriors/battles_tests.py
+++ b/warriors/battles_tests.py
@@ -36,6 +36,62 @@ def test_battle_score():
     assert battle_viewpoint.performance == pytest.approx(-0.5, abs=0.01)  # it could have been closer to 1 if there was a discrepancy in the ratings
 
 
+MIS_JOIN = pytest.mark.xfail(
+    strict=True,
+    reason="viewpoint 2 reads the other game's score (`Game.score_object` in `TODO.md`)",
+)
+
+
+@pytest.fixture
+def scored_battle():
+    battle = BattleFactory(
+        warrior_1__id=UUID(int=1),
+        warrior_2__id=UUID(int=2),
+    )
+    create_scores(
+        battle,
+        score_1_2_1=0.1, score_1_2_2=0.2,
+        score_2_1_1=0.3, score_2_1_2=0.4,
+    )
+    return battle
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ('viewpoint', 'game_name', 'similarities'),
+    (
+        ('1', 'game_1_2', (0.1, 0.2)),
+        ('1', 'game_2_1', (0.4, 0.3)),
+        pytest.param('2', 'game_1_2', (0.4, 0.3), marks=MIS_JOIN),
+        pytest.param('2', 'game_2_1', (0.1, 0.2), marks=MIS_JOIN),
+    ),
+)
+def test_game_reports_its_own_similarities(scored_battle, viewpoint, game_name, similarities):
+    """
+    A game reports the similarities of its own LLM run,
+    warrior 1 being the one its prompt concatenated first.
+    Both viewpoints see the same two games, in opposite slots.
+    """
+    game = getattr(BattleViewpoint(scored_battle, viewpoint), game_name)
+    assert (
+        game.warrior_1_preserved_ratio,
+        game.warrior_2_preserved_ratio,
+    ) == similarities
+
+
+@pytest.mark.django_db
+def test_battle_score_splits_between_viewpoints(scored_battle):
+    """
+    The two viewpoints of a battle split one outcome between them.
+    The mis-join above preserves this — which is how it stays hidden —
+    and repairing half of it does not.
+    """
+    assert (
+        BattleViewpoint(scored_battle, '1').score +
+        BattleViewpoint(scored_battle, '2').score
+    ) == pytest.approx(1)
+
+
 # transaction=True runs the test in autocommit, like a plain view request;
 # under the default test-wrapping transaction the timestamps would agree
 # even without create_from_warriors' own atomic block.


### PR DESCRIPTION
Outcome of investigating the stale `fix_battle_order` branch. Records a live defect and the constraint it puts on the game migration. **No behavior change** — docs and tests only.

## The defect

`Game.score_object` finds a `GameScore` by matching the facade's direction against the row's, but a `BattleViewpoint` rewrites field *names* and not lookup *keys*. So from viewpoint 2 each game reads the other game's score row.

A second error hides it: `BattleViewpoint.game_scores_list` wraps each row in a `GameScoreViewpoint` carrying the battle-level viewpoint, which swaps similarities that are already stored in game order. Composed, the two name the right warrior in the wrong game — so battle score, performance and rating all come out correct, and the only wrong numbers on the site are the warrior-arena page's two per-game columns, each showing what belongs to the other one.

That cancellation is why this survived unnoticed since `a0c080b` replaced the `Battle.lcs_len_*` columns with `GameScore` rows: the old `map_field_name_x_x_x` flipped direction *and* warrior index in one place, and only the warrior-index half made it into the new shape — where it is wrong anyway, since `GameScore` stores in game order while the old columns stored in battle order.

## Why it matters to `docs/game-migration.md`

Step 2 hydrates each viewpoint from its game rows, which repairs the mis-join for free and leaves the swap inverting every viewpoint-2 battle score. The step's own claim that "the score-averaging semantics are unchanged" holds only if both go, so the ordering constraint is recorded with the plan rather than only in the registry.

The fix also clears the last reader selecting on `GameScore.direction` — the condition step 1 is waiting on.

## The tests

`test_game_reports_its_own_similarities` states the contract as a parametrized table. The viewpoint-1 rows pass and are a regression guard the code did not have; the viewpoint-2 rows are `xfail(strict=True)`, so a whole fix has to come back and remove the marker.

`test_battle_score_splits_between_viewpoints` pins the invariant that hides the defect. Verified against every variant of the fix:

| | symmetry test | rating tests |
|---|---|---|
| today | pass | pass |
| direction mapped only (what `fix_battle_order` does) | **fail** | **fail** |
| swap dropped only | **fail** | **fail** |
| both (whole fix) | pass | pass |

Under the whole fix the entire suite passes untouched and the two `xfail` rows go `XPASS(strict)` — which is what verifies the entry's claim that no values move and no rating changes, so the fix needs no sign-off.

## Deliberately not here

The fix itself. It is small — map the row selection and drop the swap, after which `GameScoreViewpoint` wraps nothing and its scoring properties move back onto `GameScore` — but it changes numbers on a public page and deserves its own reviewed commit. `TODO.md` carries it as the next move.

No repair command either: every `GameScore` row in the database is correct, and `verify_games` has nothing to find. The damage is entirely on the read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzs1ePKxtUT1dx1NuXpvTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wzs1ePKxtUT1dx1NuXpvTV)_