### PR TITLE
Batch the game-score backfill by page, not by id

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -140,6 +140,30 @@ No values move and no rating changes, so no sign-off,
 and it clears the last reader selecting on `GameScore.direction` —
 what step 1 of `docs/game-migration.md` waits for.
 
+`GameScore` (`warriors/score.py`) carries two indexes
+that duplicate one already there:
+the `Meta.indexes` entry on (battle, direction, algorithm)
+names exactly the columns `unique_together` indexes,
+and the `game` foreign key's own index
+is a prefix of `unique_game_algorithm`.
+Postgres answers those lookups from the longer index either way,
+so the pair buys nothing,
+while every insert and update on the table
+writes two index entries nobody reads.
+A bulk measurement of the cost:
+dropping the two took a million-row `game_id` backfill
+from 54s to 40s.
+Next move: delete the `Meta.indexes` entry,
+set `db_index=False` on the `game` foreign key,
+and migrate the two indexes away;
+behavior-preserving.
+The `battle` foreign key's index is redundant today for the same reason
+but has to stay:
+the uniqueness covering it drops in step 1
+of `docs/game-migration.md`,
+while `WarriorArena.update_rating` still prefetches `game_scores`
+by battle until the reader cut-over in step 2.
+
 Every test that builds a `Battle` has to sort the warrior pair first,
 because `BattleFactory` passes its two `SubFactory` warriors through
 in the order given and the `warrior_ordering` check constraint

--- a/warriors/management/commands/backfill_game_score_game.py
+++ b/warriors/management/commands/backfill_game_score_game.py
@@ -6,16 +6,33 @@ but the rows that predate the column carry only (battle, direction).
 The game row is what they identify — the pair maps to it one-to-one —
 so this is a re-keying, not a repair: no value is chosen, only looked up.
 
-Set-based, batched by score id, each batch its own transaction,
+Set-based, batched by page range, each batch its own transaction,
 so it holds no long locks and can be interrupted and rerun.
-The two directions are separate statements:
-one statement would need a CASE over the swapped warrior pair
-to say which end of the battle the direction starts from.
+Batching by physical position rather than by score id is the point:
+the primary key is a random uuid,
+so a batch taken in id order scatters its rows over the whole table
+and over every index the write maintains, a page fetch each,
+and hauls every id through the client to name them.
+A page range names rows by where they already sit,
+and is wide enough that the planner hashes the games and battles once
+instead of probing per row — measured 5x on a million unlinked scores.
+`backfill_game_input_sha256` keeps the id-keyed shape
+because the rows it repairs number in the tens.
+
+Each pass reads the page count again,
+because the rows it writes extend the table as it goes.
+Its own writes only ever move a row it has already linked,
+but a concurrent write to a legacy score can move an unlinked one
+behind the cursor — so run it until it reports nothing left.
+
+Both directions go in one statement —
+the CASE that says which end of the battle a direction starts from
+costs less than a second pass over the page range.
 
 Delete this command once a production run reports nothing left to link:
 the not-null migration that follows leaves it nothing to find.
 """
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, transaction
 
 from ...score import GameScore
@@ -25,47 +42,53 @@ LINK_SQL = """
     UPDATE warriors_gamescore s
     SET game_id = g.id
     FROM warriors_battle b, warriors_game g
-    WHERE s.id = ANY(%(ids)s)
+    WHERE s.ctid >= %(start)s::tid
+      AND s.ctid < %(end)s::tid
       AND s.game_id IS NULL
-      AND s.direction = %(direction)s
       AND b.id = s.battle_id
       AND g.battle_id = b.id
-      AND g.warrior_1_id = b.{first}
+      AND g.warrior_1_id = CASE s.direction
+          WHEN '1_2' THEN b.warrior_1_id
+          WHEN '2_1' THEN b.warrior_2_id
+      END
 """
-DIRECTIONS = (
-    ('1_2', 'warrior_1_id'),
-    ('2_1', 'warrior_2_id'),
-)
+PAGE_COUNT_SQL = """
+    SELECT pg_relation_size('warriors_gamescore')
+         / current_setting('block_size')::bigint
+"""
 
 
 class Command(BaseCommand):
     help = 'Link game scores to the game row they score'
 
     def add_arguments(self, parser):
-        parser.add_argument('--batch-size', type=int, default=10000)
+        parser.add_argument('--batch-pages', type=int, default=2000)
 
-    def handle(self, *args, batch_size, **options):
-        scanned = 0
+    def handle(self, *args, batch_pages, **options):
+        if batch_pages < 1:
+            # a zero-page batch never advances the cursor
+            raise CommandError('--batch-pages must be at least 1')
+        block = 0
         linked = 0
-        last_id = None
         while True:
-            scores = GameScore.objects.filter(game=None).order_by('id')
-            if last_id is not None:
-                scores = scores.filter(id__gt=last_id)
-            ids = list(scores.values_list('id', flat=True)[:batch_size])
-            if not ids:
+            pages = self.page_count()
+            if block >= pages:
                 break
-            last_id = ids[-1]
-            scanned += len(ids)
             with transaction.atomic(), connection.cursor() as cursor:
-                for direction, first in DIRECTIONS:
-                    cursor.execute(
-                        LINK_SQL.format(first=first),
-                        {'ids': ids, 'direction': direction},
-                    )
-                    linked += cursor.rowcount
-            self.stdout.write(f'scanned {scanned}, linked {linked}')
+                cursor.execute(LINK_SQL, {
+                    'start': f'({block},0)',
+                    'end': f'({block + batch_pages},0)',
+                })
+                linked += cursor.rowcount
+            block = min(block + batch_pages, pages)
+            self.stdout.write(f'pages {block}/{pages}, linked {linked}')
         unlinked = GameScore.objects.filter(game=None).count()
         # what is left is a score whose battle direction has no game row:
         # a broken invariant for verify_games to report, not a gap to fill
         self.stdout.write(f'done: linked {linked}, {unlinked} still unlinked')
+
+    def page_count(self):
+        with connection.cursor() as cursor:
+            cursor.execute(PAGE_COUNT_SQL)
+            (pages,) = cursor.fetchone()
+        return pages

--- a/warriors/tests/test_backfill_game_score_game.py
+++ b/warriors/tests/test_backfill_game_score_game.py
@@ -16,7 +16,8 @@ def test_backfill_links_each_score_to_its_own_game():
         create_scores(battle, 1, 0.1, 1, 0.1)
     GameScore.objects.update(game=None)
 
-    call_command('backfill_game_score_game', batch_size=1)
+    # no --batch-pages: these scores share a page, so nothing splits them
+    call_command('backfill_game_score_game')
 
     for battle in battles:
         for score in battle.game_scores.all():


### PR DESCRIPTION
`backfill_game_score_game` was slow. It batched by `GameScore.id`, which is a
random uuid, so every batch of 10 000 was 10 000 rows scattered over the whole
table and over all seven of its indexes — a page fetch each — and it hauled
every id through the client to name them, twice, once per direction statement.

Batching by page range (`ctid >= '(n,0)' AND ctid < '(n+2000,0)'`) names rows by
where they already sit, and the batch is wide enough that the planner hashes the
games and battles once instead of probing per row. Both directions now go in one
statement, with a `CASE` picking which end of the battle a direction starts from.

Still set-based, one transaction per batch, interruptible and rerunnable. It
re-reads the page count each pass, because its own writes extend the table as it
goes.

## Measurement

250k battles / 500k games / 1M unlinked scores, through `manage.py`, A/B on
identical database copies of the same synthetic dataset:

| | wall |
|---|---|
| before | 286 s |
| after | **53–56 s** |
| rerun, nothing to link | ~1 s |

Verified after each run: all 1 000 000 linked, 0 still unlinked, and 0 rows
pointing at a game that isn't the one their (battle, direction) names.

## Tried and rejected

- **Bigger `--batch-size`** (10k → 100k on the old shape): 89 s → 85 s in an
  in-server harness. The scatter, not the batch count, was the cost.
- **Partial index `(id) WHERE game_id IS NULL`**: candidate selection was only
  ~4 s of the 89 s. No help.
- **Fusing the SELECT and UPDATE into one CTE**: slightly *worse* than the
  two-step, which is what rules out the in-server id round trip as the
  mechanism and leaves page locality as the explanation.

## Notes for review

- `backfill_game_input_sha256` deliberately keeps the id-keyed shape — it
  repairs rows numbering in the tens. The docstring says so, since `AGENTS.md`
  points at that command as the shape to copy and the two now differ.
- The test drops its explicit batch argument. A fixture's worth of scores all
  sit in page 0, so no page size can split them, and a `batch_pages=1` would
  read as the per-row batching that `batch_size=1` used to mean.
- `TODO.md` gains an entry for two redundant indexes on `GameScore` found while
  measuring: the `Meta.indexes` entry duplicates `unique_together` on the same
  three columns, and the `game` FK's index is a prefix of
  `unique_game_algorithm`. Dropping them takes this backfill from 54 s to 40 s
  and would lighten every write to the table. Left out of this PR — it's a
  schema migration on a hot table and wants its own review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMhhiYW6RVJcQBvah6YuEi)_