### PR TITLE
Re-derive the score links in the audit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,7 +109,7 @@ onto blank game rows.
 not an ongoing repair:
 it links the `GameScore` rows written before the `game` column existed
 to the game row their (battle, direction) pair already names.
-Delete it once a production run reports zero still unlinked —
+Delete it once `verify_games` reports no score-link finding —
 the same condition that lets the column go not-null
 in step 1 of `docs/game-migration.md`,
 so the two land together.

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -114,10 +114,13 @@ A finding nothing explains is a bug to chase, not data to copy over.
 `get_or_create_game_score` (`warriors/score.py`)
 names the game on every score it writes,
 and `backfill_game_score_game` links the rows written before it did.
-Once a production run reports nothing left to link,
+Once `verify_games` reports no score-link finding,
 the column goes not-null
 and the lookup and the uniqueness move off (battle, direction)
 onto the (game, algorithm) constraint that already guards the writes.
+The audit is the gate rather than the backfill's own count:
+the count covers the rows that command linked
+and says nothing about the ones that reached it already linked.
 `_ensure_score` then reads the game row directly —
 warriors, result text unit, finish reason —
 instead of constructing the battle facade.

--- a/warriors/management/commands/verify_games.py
+++ b/warriors/management/commands/verify_games.py
@@ -11,6 +11,12 @@ and mirrors it onto the battle's directional columns;
 the audit compares them without caring which side is authoritative,
 because equality is symmetric.
 
+It checks the same key from the score side too:
+that a score names the game it scores
+and not merely the (battle, direction) pair it was keyed on.
+A backfill reports the rows it linked and nothing about the rest,
+so whether a link is right is a question only re-deriving it answers.
+
 Nothing here is routine backfill.
 `Battle.create_from_warriors` writes a battle and both its games
 in one transaction, so a missing row is a broken invariant, not a gap;
@@ -26,7 +32,7 @@ and a page of identical lines is where the single odd one hides.
 Batched by battle id to bound memory, not for locking:
 the audit takes no locks and can be interrupted at any point.
 """
-from collections import Counter
+from collections import Counter, defaultdict
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -34,7 +40,7 @@ from ...battles import Battle, as_bytes, mirrored_game_fields
 
 
 class Command(BaseCommand):
-    help = 'Report game rows that do not mirror their battle'
+    help = 'Report game rows and score links that disagree with their battle'
 
     def add_arguments(self, parser):
         parser.add_argument('--batch-size', type=int, default=1000)
@@ -49,7 +55,9 @@ class Command(BaseCommand):
             battles = Battle.objects.order_by('id')
             if last_id is not None:
                 battles = battles.filter(id__gt=last_id)
-            battles = list(battles.prefetch_related('games')[:batch_size])
+            battles = list(
+                battles.prefetch_related('games', 'game_scores')[:batch_size]
+            )
             if not battles:
                 break
             last_id = battles[-1].id
@@ -63,13 +71,20 @@ class Command(BaseCommand):
 
     def check_battle(self, battle):
         games = {game.warrior_1_id: game for game in battle.games.all()}
+        scores = defaultdict(list)
+        for score in battle.game_scores.all():
+            scores[score.direction].append(score)
         for direction in ('1_2', '2_1'):
             fields = mirrored_game_fields(battle, direction)
             game = games.pop(fields['warrior_1_id'], None)
             location = f'battle {battle.id} game {direction}'
             if game is None:
+                # with no row there is nothing for its scores to name
                 self.record('missing game row', location)
-            elif game.resolved_at is None:
+                continue
+            # a link never drifts mid-flight, so the gate below misses it
+            self.check_scores(scores[direction], game, location)
+            if game.resolved_at is None:
                 # A direction still in flight is being written as we read:
                 # attempts climbs on every retry, and the battle and its
                 # games arrive in separate queries, so comparing them
@@ -85,6 +100,23 @@ class Command(BaseCommand):
                 'game row outside the battle pair',
                 f'battle {battle.id} warrior {warrior_1_id}',
             )
+
+    def check_scores(self, scores, game, location):
+        """
+        The scores of one direction, against the game they score.
+
+        The pair a score is keyed on names exactly one game row, so the
+        link is re-derivable — and re-deriving is the only thing that
+        checks it: the (game, algorithm) uniqueness rejects two scores
+        meeting on one game, so a battle whose two scores name each
+        other's game satisfies every constraint in the schema.
+        """
+        for score in scores:
+            score_location = f'{location} score {score.algorithm}'
+            if score.game_id is None:
+                self.record('score naming no game', score_location)
+            elif score.game_id != game.id:
+                self.record('score naming the wrong game', score_location)
 
     def check_game(self, game, fields, location):
         for name, expected in fields.items():

--- a/warriors/tests/test_verify_games.py
+++ b/warriors/tests/test_verify_games.py
@@ -4,7 +4,11 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 
 from ..battles import LLM
-from .factories import BattleFactory, TextUnitFactory, WarriorFactory
+from ..score import ScoreAlgorithm
+from .factories import (
+    BattleFactory, GameScoreFactory, TextUnitFactory, WarriorFactory, game_of,
+)
+from .fixtures import create_scores
 
 
 @pytest.fixture
@@ -120,6 +124,41 @@ def test_verify_reports_a_resolution_the_mirror_missed(mirrored_battle):
     mirrored_battle.save(update_fields=['resolved_at_1_2'])
 
     with pytest.raises(CommandError, match='conflicting resolved_at: 1'):
+        call_command('verify_games')
+
+
+@pytest.mark.django_db
+def test_verify_accepts_scores_naming_their_own_game(mirrored_battle):
+    create_scores(mirrored_battle, 1, 0.1, 1, 0.1)
+
+    call_command('verify_games')
+
+
+@pytest.mark.django_db
+def test_verify_reports_an_unlinked_score(mirrored_battle):
+    # what backfill_game_score_game repairs — and the report that says
+    # it is done, which the command's own count cannot: it sees only the
+    # rows it linked, never the ones that arrived linked
+    create_scores(mirrored_battle, 1, 0.1, 1, 0.1)
+    mirrored_battle.game_scores.update(game=None)
+
+    with pytest.raises(CommandError, match='score naming no game: 2'):
+        call_command('verify_games')
+
+
+@pytest.mark.django_db
+def test_verify_reports_scores_naming_each_others_game(mirrored_battle):
+    # both rows insert, so the swap is the one mislinking the schema
+    # accepts — every other one meets on a game (game, algorithm) guards
+    for direction, other in (('1_2', '2_1'), ('2_1', '1_2')):
+        GameScoreFactory(
+            battle=mirrored_battle,
+            direction=direction,
+            algorithm=ScoreAlgorithm.LCS,
+            game=game_of(mirrored_battle, other),
+        )
+
+    with pytest.raises(CommandError, match='score naming the wrong game: 2'):
         call_command('verify_games')
 
 


### PR DESCRIPTION
A production run of `backfill_game_score_game` reported `linked 0, 0 still unlinked`.
That is the condition step 1 of `docs/game-migration.md` waits on,
but the number cannot carry the weight the plan puts on it:
the command skips every row that already has a game,
so whatever linked those — an earlier run of the id-keyed version, the writer —
goes unchecked.

The uniqueness on `(game, algorithm)` rejects two scores meeting on one game,
which leaves exactly one mislinking the schema still accepts:
a battle whose two scores name each other's game.
Nothing reports it today.

`verify_games` now re-derives each score's link
from the `(battle, direction)` pair it is keyed on
and reports `score naming no game` / `score naming the wrong game`,
folded into the direction loop that already resolves the game row —
so the mapping is not restated a third time.
The check sits outside the in-flight gate the mirror comparison needs:
that gate exists because `attempts` climbs while a direction retries,
and a link is written once and never moves.

The delete condition for `backfill_game_score_game` moves with it,
in both `TODO.md` and the migration plan:
from "a production run reports zero still unlinked" — already true,
so it read as "delete now" — to "`verify_games` reports no score-link finding".

## Verification

Full `warriors/` suite green (147 passed, 3 real_world deselected,
2 xfail — the known viewpoint-2 mis-join cases), flake8 clean.
Both new failure tests were confirmed to fail with the check disabled.

The viewpoint-2 mis-join documented in `TODO.md` does not touch any of this:
it is read-side only, and every writer builds `Game` on a raw `Battle`
(`resolve_battle`, `_ensure_score`),
so `GameScore.direction` and the similarities stored under it
are in game order and the re-keying by direction is sound.

## Next

`./manage.py verify_games` on production is what gives step 1 its real gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_016aSUHLUR5BSuDBkQeRYJvC)_