### PR TITLE
Write down the symmetric battle result display

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -294,3 +294,16 @@ silently losing the warrior walk rather than failing.
 Next move: expose `battle_url` as a template tag
 and call it from those four links,
 leaving the parameter named once on each side of the request.
+
+The cooperation-score table in `templates/warriors/partials/game.html`
+hand-writes one row per scoring algorithm,
+naming LCS and embeddings in the markup,
+so a third `ScoreAlgorithm` member renders nowhere until someone edits it.
+The duplication has already drifted:
+the embeddings row lost its opening `<tr>` and kept the closing one.
+It renders — the parser opens a row implicitly for the stray `<td>` —
+so nothing looks wrong, which is why it survived.
+Next move: loop over the game's score rows instead,
+which drops both the stray tag and the names
+(`docs/battle-display.md` argues the wider case
+for looping over algorithms rather than naming one).

--- a/docs/battle-display.md
+++ b/docs/battle-display.md
@@ -1,0 +1,182 @@
+# Battle result display: symmetric in games, symmetric in algorithms
+
+A proposal, not shipped code.
+It owns the target shape of the battle result presentation
+for the reader cut-over in `docs/game-migration.md`,
+where the templates change anyway.
+
+The present display privileges one member
+of each of two sets the data treats as peers:
+one game of the two, and one scoring algorithm of the two.
+Neither privilege comes from the game;
+both come from how the values were once stored and once computed.
+The display that stops asserting them
+is also the display that stops caring
+how many games and how many algorithms exist.
+
+## Symmetric in games
+
+The battle page has two named slots
+(`battle_detail.html` renders `game_1_2` and `game_2_1`
+under fixed headings and fixed anchors),
+and the accessors that feed them are named for directions.
+
+The grounded argument is not a hypothetical third game
+but the pair itself:
+the two games resolve independently,
+so for a while a battle has one resolved game and one pending.
+Where the display is already per game
+it takes that in stride —
+the game partial branches on its own game's `resolved_at` —
+and where the pair is named,
+`warriorarena_detail.html` spells the state out per direction
+three times in one table row.
+The difference is the whole argument in miniature:
+looping is what makes the partial-resolution case ordinary.
+
+That the count could exceed two is a bonus rather than the case:
+nothing in the domain fixes it at two,
+and reruns after a model version change,
+or a matchup replayed against a second LLM,
+would each want a row where today there is a named slot.
+Neither exists, and this proposal does not argue for them.
+
+## Symmetric in scoring algorithms
+
+Every resolved game is scored by every algorithm:
+`resolve_battle` (`warriors/tasks.py`) writes an LCS score
+and an embeddings score unconditionally.
+The storage is symmetric; the display is not.
+LCS supplies the page's unqualified numbers —
+the meters, the preserved ratios, the battle score —
+while embeddings is reached through a special-cased property
+(`Game.embedding_scoring`, which builds a second facade
+with the algorithm name written into it)
+and rendered under an "experimental" heading.
+`BattleViewpoint` carries a `score_algorithm` defaulting to LCS,
+so `BattleDetailView`, which names no algorithm, gets LCS by omission.
+
+That default has no owner.
+Which algorithm is authoritative is a property of a *ranking*,
+not of a battle:
+today `Arena.score_algorithm`,
+and under the target shape in `docs/data-model.md`
+part of the ranking registry key,
+so several rankings can read one battle through different algorithms.
+The battle page belongs to no arena and no ranking —
+it is the record of what happened —
+which leaves it no basis for calling one column the score
+and the other experimental.
+
+The display should loop over the algorithms
+the way it loops over the games.
+The test is mechanical:
+a third member of `ScoreAlgorithm` should reach the battle page
+without a template edit.
+Today each algorithm is a hand-written block,
+and hand-written per-algorithm blocks drift —
+`TODO.md` carries the instance.
+
+Symmetric does not mean identical.
+LCS can mark the surviving subsequence inside the result text
+and an embedding similarity has nothing to mark,
+so algorithm-specific extras hang off their own algorithm's block.
+What goes away is one algorithm's numbers standing unqualified
+while the others are guests.
+Where a number does feed a ranking,
+that is an annotation on it, not a reason to structure the page around it.
+
+## The shape
+
+Three axes — game, algorithm, warrior — and a page renders two at a time.
+
+The battle summary is a matrix per algorithm,
+reached by looping over algorithms rather than naming any:
+a row per warrior, a column per game,
+each cell that warrior's score in that game,
+and a margin column holding the mean, which is the battle score.
+Every column sums to one, the margin column included,
+so a reader can check the arithmetic by eye —
+the practical test of a symmetric presentation.
+Warrior similarity and the cooperation score built from it
+are per battle and per algorithm, not per game,
+so they sit beside that algorithm's matrix
+instead of being repeated in every game block.
+
+Each game then gets its own block:
+the result text, and its scores by algorithm and by warrior.
+
+For a cell to be addressable at all,
+a game's score has to be askable *for a named warrior*,
+rather than as a positional `score`
+with the other side derived as the remainder.
+That is mechanism in service of the two symmetries,
+with a payoff of its own:
+the viewpoint machinery
+(`BattleViewpoint`'s field rewriting, the in-memory `Game` facade,
+the `GameScoreViewpoint` swap)
+exists to make "1" mean "the warrior this page is about",
+and per-warrior addressing retires all of it.
+The two canceling errors in the `Game.score_object` entry of `TODO.md`
+are possible only because "which warrior is 1"
+is a rewriting concern applied at two levels instead of a lookup key.
+
+## What stays asymmetric, deliberately
+
+Prompt order inside a game is the variable
+that playing both directions controls for,
+so it stays visible per game.
+The battle's canonical warrior order stays too —
+pair identity, matchmaking exclusion,
+and the uniqueness constraint all key off it.
+Symmetry here means an order or an algorithm choice
+is data the page reports,
+not structure baked into slot names, field names, and defaults.
+Performance stays pairwise:
+it is a score minus a rating-model expectation for two warriors
+(`BattleViewpoint.performance`),
+and no expectation is defined for a wider battle.
+
+## Decisions to settle before coding
+
+- **What the battle lists show.**
+  A battle page has room for every game and every algorithm;
+  a list row has room for neither.
+  The warrior-arena list is arena-scoped,
+  so it has an owner to ask for an algorithm —
+  the one place where naming one is legitimate.
+  Its fixed pair of per-direction score columns is the harder half:
+  either keep two columns while every battle has two games,
+  or collapse to the warrior's battle score
+  and leave per-game detail to the battle page.
+- **Battle score with a game missing.**
+  Mean over resolved games, or "pending" until all are in?
+  Display can reasonably show the partial mean with a count;
+  rating must not — its resolved-battle filter
+  stays "every game of this battle is resolved"
+  (the `BattleQuerySet.resolved()` change
+  in step 1 of `docs/game-migration.md`).
+  The two coincide by accident, and the split should be deliberate.
+- **Anchors.**
+  Per-game anchors are direction strings linked from the battle list.
+  With N games the stable name is the game's own id,
+  and the accepted cost is that old fragment links
+  land at the top of the right battle page;
+  the battle URL itself is unchanged.
+- **Whether a warrior's battle score under an algorithm
+  becomes a named thing in code** that rating also calls,
+  rather than a display-only computation.
+  Rating's averaging semantics are unchanged either way;
+  the question is whether one definition serves both.
+
+## Sequencing
+
+Written against the battle's directional columns,
+a symmetric renderer has to reconstruct games from suffixed field names —
+a second facade beside the one being deleted.
+`GameScore` already keys on (game, algorithm),
+so what is left to wait for is the viewpoint-2 score mis-join
+(the `Game.score_object` entry in `TODO.md`),
+which step 1 of `docs/game-migration.md` gates on for the same reason.
+That makes this the shape of step 1's view and template work,
+not a separate project after it.

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -137,11 +137,13 @@ In order of blast radius:
   `BattleDetailView`, `RecentBattlesView`,
   and the warrior-detail battle list keep their battle-level shape,
   prefetching games and scores through the battle.
-  Templates already think in per-direction games
-  (`templates/warriors/partials/game.html`),
-  so a thin viewpoint wrapper over (battle, game, game)
-  preserves the template contract
-  while `BattleViewpoint`'s string-rewriting field maps disappear.
+  The target presentation is in `docs/battle-display.md`:
+  loop over a battle's games and over the scoring algorithms
+  instead of naming two directional slots and a default algorithm,
+  and select a score by (game, warrior) rather than by direction.
+  That is what makes `BattleViewpoint`'s string-rewriting field maps
+  and the `GameScoreViewpoint` swap disappear
+  rather than move.
 - **Matchmaking and stats**: no change —
   cooldown, opponent exclusion, and `battle_count`
   are pair-level and stay on `Battle`.


### PR DESCRIPTION
Docs only — no code, no behavior change. Records the target shape of the battle result presentation so the reader cut-over in `docs/game-migration.md` has something to aim at while it is still deciding what the templates become.

## The argument

The battle page privileges one member of each of two sets the data treats as peers, and neither privilege comes from the game:

**One game of the two.** `battle_detail.html` renders `game_1_2` and `game_2_1` into fixed slots with fixed anchors. The grounded cost is not a hypothetical third game but the pair itself — the two games resolve independently, so a battle spends time with one game resolved and one pending. Where the display is already per game it takes that in stride; where the pair is named, `warriorarena_detail.html` spells the state out per direction three times in one table row.

**One scoring algorithm of the two.** `resolve_battle` writes an LCS score and an embeddings score for every resolved game, so the storage is symmetric. The display is not: LCS supplies the unqualified numbers, embeddings arrives via `Game.embedding_scoring` under an "experimental" heading, and `BattleViewpoint`'s `score_algorithm` defaults to LCS — which `BattleDetailView` inherits by naming no algorithm. That default has no owner. Which algorithm is authoritative is a property of a *ranking* (`Arena.score_algorithm` today, part of the ranking registry key under `docs/data-model.md`), and the battle page belongs to no ranking.

## What the doc contains

- The two symmetries, and what stays asymmetric on purpose — prompt order within a game, the battle's canonical pair order, and pairwise performance.
- The target shape: three axes (game, algorithm, warrior), two rendered at a time.
- Why it pays for itself: per-warrior score addressing retires the viewpoint machinery (`BattleViewpoint` field rewriting, the `Game` facade, the `GameScoreViewpoint` swap) rather than porting it, and makes the canceling-error class in the `Game.score_object` TODO unrepresentable.
- Four open decisions left open, including the display/rating split on partially resolved battles.
- Sequencing: `GameScore` already keys on (game, algorithm), so the one thing still gating this is the viewpoint-2 score mis-join — which step 1 of `docs/game-migration.md` gates on for the same reason.

## Other files

- `docs/game-migration.md` — step 1's views-and-templates bullet points at the new doc instead of promising to preserve the current template contract.
- `TODO.md` — the cooperation-score table hand-writes a row per algorithm, and the duplication has drifted: the embeddings row lost its opening `<tr>` and kept the closing one. It renders (the parser opens a row implicitly for the stray `<td>`), which is why it survived.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt4W1iviavrLWMsDa8QpCU)_