### PR TITLE
Read a game's score off the game it names

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,34 +105,6 @@ a repair command that recomputes the sha from the warrior bodies
 onto blank game rows.
 `backfill_game_input_sha256` goes with the columns it copies from.
 
-`Game.score_object` (`warriors/battles.py`) finds a score row
-by matching the facade's direction against the row's,
-but a `BattleViewpoint` rewrites field names and not lookup keys,
-so from viewpoint 2 each game reads the other game's score.
-A second error hides it:
-`BattleViewpoint.game_scores_list` wraps each row in a
-`GameScoreViewpoint` carrying the battle-level viewpoint,
-which swaps similarities already stored in game order.
-Composed, they name the right warrior in the wrong game,
-so battle scores, performance, and ratings come out correct
-and only the warrior-arena page's two per-game columns are wrong,
-each showing what belongs to the other one
-(the xfail cases of `test_game_reports_its_own_similarities`).
-Repairing either error alone inverts every viewpoint-2 battle score —
-the unmerged `fix_battle_order` branch repairs the first —
-which `test_battle_score_splits_between_viewpoints`
-and the rating tests catch.
-Next move: select the score by the game row rather than the direction
-and drop the swap in the same change.
-`GameScoreViewpoint` then wraps nothing,
-so its scoring properties move onto `GameScore`
-and `BattleViewpoint.game_scores_list` goes with it.
-No values move and no rating changes, so no sign-off,
-and it leaves `GameScore.direction` with one reader —
-the audit's re-derivation of the score link —
-which goes with the directional columns
-in step 2 of `docs/game-migration.md`.
-
 The `game` foreign key on `GameScore` (`warriors/score.py`)
 carries an index nobody reads:
 it is a prefix of `unique_game_algorithm`,
@@ -152,6 +124,20 @@ nothing else covers it,
 and `WarriorArena.update_rating` prefetches `game_scores`
 by battle until the reader cut-over
 in step 1 of `docs/game-migration.md`.
+
+`GameScore.cooperation_score` (`warriors/score.py`) has no test.
+It is the one scoring property nothing exercises directly:
+`score` and `score_rev` are asserted in `score_tests.py`
+and again through the game facade in `battles_tests.py`,
+while this one is only ever rendered
+(`templates/warriors/partials/game.html`).
+It also carries the edge cases the others do not —
+a non-positive larger similarity short-circuiting to 0,
+and the `1 - warriors_similarity` factor
+that is the whole point of the axis
+(`docs/design-tensions.md` owns why it matters).
+Next move: a parametrized test beside the LCS score tests
+covering the zero case, a missing similarity, and one worked pair.
 
 Every test that builds a `Battle` has to sort the warrior pair first,
 because `BattleFactory` passes its two `SubFactory` warriors through

--- a/docs/battle-display.md
+++ b/docs/battle-display.md
@@ -113,13 +113,14 @@ with the other side derived as the remainder.
 That is mechanism in service of the two symmetries,
 with a payoff of its own:
 the viewpoint machinery
-(`BattleViewpoint`'s field rewriting, the in-memory `Game` facade,
-the `GameScoreViewpoint` swap)
+(`BattleViewpoint`'s field rewriting, the in-memory `Game` facade)
 exists to make "1" mean "the warrior this page is about",
 and per-warrior addressing retires all of it.
-The two canceling errors in the `Game.score_object` entry of `TODO.md`
-are possible only because "which warrior is 1"
-is a rewriting concern applied at two levels instead of a lookup key.
+Rewriting is also what makes "which warrior is 1"
+a property of the read path rather than a key,
+so the same game has more than one spelling
+and a lookup can take the wrong one;
+`Game.score_object` says why its lookup is keyed on the game.
 
 ## What stays asymmetric, deliberately
 
@@ -174,9 +175,9 @@ and no expectation is defined for a wider battle.
 Written against the battle's directional columns,
 a symmetric renderer has to reconstruct games from suffixed field names —
 a second facade beside the one being deleted.
-`GameScore` already keys on (game, algorithm),
-so what is left to wait for is the viewpoint-2 score mis-join
-(the `Game.score_object` entry in `TODO.md`),
-which step 1 of `docs/game-migration.md` gates on for the same reason.
-That makes this the shape of step 1's view and template work,
+`GameScore` already keys on (game, algorithm)
+and is already selected by the game it names,
+so a per-warrior lookup has something to sit on.
+That makes this the shape of step 1's view and template work
+in `docs/game-migration.md`,
 not a separate project after it.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -21,7 +21,7 @@ Gameplay decomposes into four independent axes:
    (see `resolve_battle` in `warriors/tasks.py`).
 3. **Winner computation** —
    pure code deriving a score from the similarities,
-   per algorithm (`GameScoreViewpoint.score` in `warriors/score.py`).
+   per algorithm (`GameScore.score` in `warriors/score.py`).
 4. **Leaderboard rating** —
    mELO state on `WarriorArena` (`warriors/rating_models.py`).
 

--- a/docs/game-migration.md
+++ b/docs/game-migration.md
@@ -111,13 +111,15 @@ A finding nothing explains is a bug to chase, not data to copy over.
 
 ### 1. Cut the remaining readers over
 
-Not before the viewpoint-2 score mis-join is fixed
-(the `Game.score_object` entry in `TODO.md`):
-hydrating a viewpoint from its game rows
-repairs one of two errors that cancel each other,
-and repairing either one alone moves every rating.
-The averaging claim in the rating bullet below
-survives this step only if both go.
+Scores select by the game row
+(`Game.score_object`, `warriors/battles.py`)
+and a viewpoint rewrites nothing on their way out,
+so hydrating one from its game rows
+changes where the values come from, not what they are.
+A direction label is the one key to keep out of that lookup:
+it is battle-relative where a facade's direction is not,
+and nothing cancels the difference,
+so it lands on every rating rather than on two columns of a page.
 
 In order of blast radius:
 
@@ -142,8 +144,7 @@ In order of blast radius:
   instead of naming two directional slots and a default algorithm,
   and select a score by (game, warrior) rather than by direction.
   That is what makes `BattleViewpoint`'s string-rewriting field maps
-  and the `GameScoreViewpoint` swap disappear
-  rather than move.
+  disappear rather than move.
 - **Matchmaking and stats**: no change —
   cooldown, opponent exclusion, and `battle_count`
   are pair-level and stay on `Battle`.
@@ -169,9 +170,8 @@ The dead `rating_transferred_at` column
 `GameScore.battle` and `GameScore.direction` drop here too.
 They carry no key any more —
 the uniqueness and the lookup sit on (game, algorithm) —
-and their last two readers go in this same step:
-`Game.score_object` with the facade,
-and the audit's own re-derivation of the score link with the command.
+and `direction`'s last reader goes in this same step:
+the audit's own re-derivation of the score link, with the command.
 
 ### 3. Rename
 

--- a/warriors/battles.py
+++ b/warriors/battles.py
@@ -16,7 +16,7 @@ from django_goals.utils import GoalRelatedMixin
 from .lcs import lcs_ranges
 from .rating import get_expected_game_score
 from .rating_models import M_ELO_K, normalize_playstyle_len
-from .score import GameScoreViewpoint, ScoreAlgorithm
+from .score import ScoreAlgorithm
 from .text_unit import TextUnit
 from .warriors import Warrior
 
@@ -416,6 +416,9 @@ class BattleViewpoint:
             'get_llm_display',
             'scheduled_at',
             'rating_transferred_at',
+            # a viewpoint neither renames nor reorders score rows;
+            # a game picks its own out of the list by its warriors
+            'game_scores_list',
         ):
             return field_name
         if field_name in (
@@ -464,13 +467,6 @@ class BattleViewpoint:
             elif '2_1' in field_name:
                 return field_name.replace('2_1', '1_2')
         assert False
-
-    @cached_property
-    def game_scores_list(self):
-        return tuple(
-            GameScoreViewpoint(gs, self.viewpoint)
-            for gs in self.battle.game_scores_list
-        )
 
     # game_1_id and game_2_id are used for anchor links
     @property
@@ -603,9 +599,17 @@ class Game:
 
     @property
     def score_object(self):
+        """
+        The score row of this game, under this game's algorithm.
+
+        Keyed on the warrior going first, which identifies the game row.
+        A stored `direction` is battle-relative where this facade's is
+        relative to whatever it wraps, so from viewpoint 2 the two spell
+        the same game differently.
+        """
         for game_score in self.battle.game_scores_list:
             if (
-                game_score.direction == self.direction and
+                game_score.game.warrior_1_id == self.warrior_1_id and
                 game_score.algorithm == self.score_algorithm
             ):
                 return game_score

--- a/warriors/battles_tests.py
+++ b/warriors/battles_tests.py
@@ -1,9 +1,11 @@
 from uuid import UUID
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from .battles import Battle, BattleViewpoint
-from .tests.factories import BattleFactory, WarriorArenaFactory
+from .tests.factories import BattleFactory, WarriorArenaFactory, WarriorFactory
 from .tests.fixtures import create_scores
 from .text_unit import TextUnit
 
@@ -36,12 +38,6 @@ def test_battle_score():
     assert battle_viewpoint.performance == pytest.approx(-0.5, abs=0.01)  # it could have been closer to 1 if there was a discrepancy in the ratings
 
 
-MIS_JOIN = pytest.mark.xfail(
-    strict=True,
-    reason="viewpoint 2 reads the other game's score (`Game.score_object` in `TODO.md`)",
-)
-
-
 @pytest.fixture
 def scored_battle():
     battle = BattleFactory(
@@ -62,8 +58,8 @@ def scored_battle():
     (
         ('1', 'game_1_2', (0.1, 0.2)),
         ('1', 'game_2_1', (0.4, 0.3)),
-        pytest.param('2', 'game_1_2', (0.4, 0.3), marks=MIS_JOIN),
-        pytest.param('2', 'game_2_1', (0.1, 0.2), marks=MIS_JOIN),
+        ('2', 'game_1_2', (0.4, 0.3)),
+        ('2', 'game_2_1', (0.1, 0.2)),
     ),
 )
 def test_game_reports_its_own_similarities(scored_battle, viewpoint, game_name, similarities):
@@ -83,13 +79,46 @@ def test_game_reports_its_own_similarities(scored_battle, viewpoint, game_name, 
 def test_battle_score_splits_between_viewpoints(scored_battle):
     """
     The two viewpoints of a battle split one outcome between them.
-    The mis-join above preserves this — which is how it stays hidden —
-    and repairing half of it does not.
+    Selecting a game and labelling its warriors are separate steps,
+    and getting one right while the other is wrong
+    leaves the pair summing to something other than 1.
     """
     assert (
         BattleViewpoint(scored_battle, '1').score +
         BattleViewpoint(scored_battle, '2').score
     ) == pytest.approx(1)
+
+
+@pytest.mark.django_db
+def test_reading_scores_costs_no_query_per_battle():
+    """
+    A game reaches its score through the game row the score names,
+    so a read path fetching battles without their games
+    pays one query per score row.
+    The scores come out right either way,
+    which leaves the query count as the only thing that shows it.
+    """
+    warrior = WarriorFactory(id=UUID(int=1))
+
+    def add_battle(warrior_2_id):
+        battle = BattleFactory(warrior_1=warrior, warrior_2__id=UUID(int=warrior_2_id))
+        create_scores(
+            battle,
+            score_1_2_1=0.1, score_1_2_2=0.2,
+            score_2_1_1=0.3, score_2_1_2=0.4,
+        )
+
+    def queries_to_score_every_battle():
+        with CaptureQueriesContext(connection) as queries:
+            for battle in Battle.objects.prefetch_related('game_scores__game'):
+                BattleViewpoint(battle, '1').score
+        return len(queries)
+
+    add_battle(2)
+    one_battle = queries_to_score_every_battle()
+    for warrior_2_id in range(3, 6):
+        add_battle(warrior_2_id)
+    assert queries_to_score_every_battle() == one_battle
 
 
 # transaction=True runs the test in autocommit, like a plain view request;

--- a/warriors/rating_models.py
+++ b/warriors/rating_models.py
@@ -66,7 +66,8 @@ class RatingMixin(models.Model):
         for b in Battle.objects.with_warrior_arena(self).resolved().order_by(
             '-scheduled_at',
         ).prefetch_related(
-            'game_scores',
+            # a score is selected by its game's warriors, so bring the game
+            'game_scores__game',
         ):
             b = b.get_warrior_viewpoint(self, score_algorithm=self.arena.score_algorithm)
             if b.warrior_2_id in battles:

--- a/warriors/score.py
+++ b/warriors/score.py
@@ -1,5 +1,4 @@
 import uuid
-from dataclasses import dataclass
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -16,7 +15,12 @@ class ScoreAlgorithm(models.TextChoices):
 
 class GameScore(GoalRelatedMixin, models.Model):
     """
-    Stores the score for a single game (battle direction) and scoring algorithm.
+    One game's score under one scoring algorithm.
+
+    Similarities are stored in game order,
+    the order a reader of the game sees its warriors in,
+    so the scoring properties read straight off the row
+    with nothing rewriting them on the way out.
     """
     id = models.UUIDField(
         primary_key=True,
@@ -67,6 +71,66 @@ class GameScore(GoalRelatedMixin, models.Model):
                 name='unique_game_algorithm',
             ),
         ]
+
+    @property
+    def score(self):
+        """
+        Score of warrior 1.
+        Score of warrior 2 is `1 - score`.
+        """
+        if self.warrior_1_similarity is None or self.warrior_2_similarity is None:
+            return None
+
+        if self.algorithm == ScoreAlgorithm.LCS:
+            if self.warrior_1_similarity + self.warrior_2_similarity == 0:
+                return 0.5
+            return self.warrior_1_similarity / (self.warrior_1_similarity + self.warrior_2_similarity)
+
+        if self.algorithm == ScoreAlgorithm.EMBEDDINGS:
+            if self.warrior_1_similarity > self.warrior_2_similarity:
+                return 1.0
+            elif self.warrior_1_similarity < self.warrior_2_similarity:
+                return 0.0
+            else:
+                return 0.5
+
+    @property
+    def score_rev(self):
+        """
+        Score of warrior 2.
+        """
+        s = self.score
+        if s is None:
+            return None
+        return 1.0 - s
+
+    @property
+    def cooperation_score(self):
+        """
+        Fusion quality, as opposed to who won:
+        high when both prompts survive into the output in balance
+        (the smaller-to-larger similarity ratio)
+        and are distinct to begin with —
+        the ``1 - warriors_similarity`` factor zeroes out mutual copying,
+        where balanced survival would be trivial.
+        For why this axis matters, see "The central tension"
+        in docs/design-tensions.md.
+        """
+        if (
+            self.warriors_similarity is None or
+            self.warrior_1_similarity is None or
+            self.warrior_2_similarity is None
+        ):
+            return None
+        smaller_similarity, larger_similarity = sorted([
+            self.warrior_1_similarity,
+            self.warrior_2_similarity,
+        ])
+        if larger_similarity <= 0:
+            return 0
+        return (
+            smaller_similarity / larger_similarity
+        ) * (1 - self.warriors_similarity)
 
 
 def get_or_create_game_score(game, direction, algorithm):
@@ -188,86 +252,3 @@ def _set_similarity(
             'warrior_2_similarity',
             'warriors_similarity',
         ])
-
-
-@dataclass(frozen=True)
-class GameScoreViewpoint:
-    game_score: GameScore
-    viewpoint: str  # 1 is normal, 2 is reversed
-
-    def __getattr__(self, key):
-        if key in (
-            'direction',
-            'algorithm',
-        ):
-            return getattr(self.game_score, key)
-
-        w1, w2 = ('1', '2') if self.viewpoint == '1' else ('2', '1')
-        if key == 'warrior_1_similarity':
-            return getattr(self.game_score, f'warrior_{w1}_similarity')
-        if key == 'warrior_2_similarity':
-            return getattr(self.game_score, f'warrior_{w2}_similarity')
-        if key == 'warriors_similarity':
-            return self.game_score.warriors_similarity
-
-        return super().__getattribute__(key)
-
-    @property
-    def score(self):
-        """
-        Score of warrior 1.
-        Score of warrior 2 is `1 - score`.
-        """
-        if self.warrior_1_similarity is None or self.warrior_2_similarity is None:
-            return None
-
-        if self.algorithm == ScoreAlgorithm.LCS:
-            if self.warrior_1_similarity + self.warrior_2_similarity == 0:
-                return 0.5
-            return self.warrior_1_similarity / (self.warrior_1_similarity + self.warrior_2_similarity)
-
-        if self.algorithm == ScoreAlgorithm.EMBEDDINGS:
-            if self.warrior_1_similarity > self.warrior_2_similarity:
-                return 1.0
-            elif self.warrior_1_similarity < self.warrior_2_similarity:
-                return 0.0
-            else:
-                return 0.5
-
-    @property
-    def score_rev(self):
-        """
-        Score of warrior 2.
-        """
-        s = self.score
-        if s is None:
-            return None
-        return 1.0 - s
-
-    @property
-    def cooperation_score(self):
-        """
-        Fusion quality, as opposed to who won:
-        high when both prompts survive into the output in balance
-        (the smaller-to-larger similarity ratio)
-        and are distinct to begin with —
-        the ``1 - warriors_similarity`` factor zeroes out mutual copying,
-        where balanced survival would be trivial.
-        For why this axis matters, see "The central tension"
-        in docs/design-tensions.md.
-        """
-        if (
-            self.warriors_similarity is None or
-            self.warrior_1_similarity is None or
-            self.warrior_2_similarity is None
-        ):
-            return None
-        smaller_similarity, larger_similarity = sorted([
-            self.warrior_1_similarity,
-            self.warrior_2_similarity,
-        ])
-        if larger_similarity <= 0:
-            return 0
-        return (
-            smaller_similarity / larger_similarity
-        ) * (1 - self.warriors_similarity)

--- a/warriors/score_tests.py
+++ b/warriors/score_tests.py
@@ -5,7 +5,7 @@ import pytest
 from django_goals.busy_worker import worker
 from django_goals.models import Goal
 
-from .score import GameScoreViewpoint, ScoreAlgorithm, get_or_create_game_score
+from .score import ScoreAlgorithm, get_or_create_game_score
 from .tests.factories import TextUnitFactory, game_of
 
 
@@ -82,9 +82,8 @@ def test_gamescore_embeddings_integration(battle, direction):
     )
 
     # Since expected_sim_1 > expected_sim_2, warrior_1 should win
-    game_score_viewpoint = GameScoreViewpoint(game_score=game_score, viewpoint='1')
-    assert game_score_viewpoint.score == 1.0
-    assert game_score_viewpoint.score_rev == 0.0
+    assert game_score.score == 1.0
+    assert game_score.score_rev == 0.0
 
 
 @pytest.mark.django_db

--- a/warriors/views.py
+++ b/warriors/views.py
@@ -92,7 +92,8 @@ class WarriorDetailView(WarriorViewMixin, DetailView):
         battles_qs = Battle.objects.with_warrior_arena(
             warrior_arena,
         )[:100].prefetch_related(
-            'game_scores',
+            # a score is selected by its game's warriors, so bring the game
+            'game_scores__game',
         )
         battles = list(battles_qs)
         prefetch_warriors(battles)


### PR DESCRIPTION
Clears the gate that step 1 of `docs/game-migration.md` waits on: the viewpoint-2 score mis-join.

## The bug

Two errors that cancelled each other.

`Game.score_object` found a score row by matching a direction label, but a label is battle-relative while the facade asking for it is relative to its viewpoint — so from viewpoint 2 each game read *the other game's* score. Hiding that, `BattleViewpoint.game_scores_list` wrapped every row in a `GameScoreViewpoint` swap of similarities that were already stored in game order.

Composed, they put the right warrior's name on the wrong game's numbers. Battle scores, performance and ratings came out correct; only the warrior-arena page's two per-game columns were wrong, each showing what belonged to the other one.

## The fix

Both errors go in one change, because repairing either alone inverts every viewpoint-2 battle score:

- the lookup keys on the warrior going first, which identifies the game row, instead of on a direction label;
- `GameScoreViewpoint` is deleted rather than adjusted — its `score`, `score_rev` and `cooperation_score` move onto `GameScore`, whose fields are already in game order, so nothing rewrites them on the way out.

`GameScore.direction` is left with a single reader (the audit's re-derivation), which drops with the directional columns in step 2.

## Verification

**Battle-level scores are unchanged to the bit** — measured by stashing the change and re-probing the same fixture:

| | before | after |
|---|---|---|
| viewpoint 1 battle score | `0.38095238095238093` | `0.38095238095238093` |
| viewpoint 2 battle score | `0.6190476190476191` | `0.6190476190476191` |
| viewpoint 2 `game_1_2` | `w1=0.2 w2=0.1` (wrong game, swapped) | `w1=0.4 w2=0.3` |
| viewpoint 2 `game_2_1` | `w1=0.3 w2=0.4` | `w1=0.1 w2=0.2` |

No rating moves. `warriors/` goes from 146 passed + 2 xfailed to 149 passed, 0 xfailed — the two `MIS_JOIN` cases now pass, and one test is new. `makemigrations --check` reports no schema change; flake8 and pylint are clean.

The unmerged `fix_battle_order` branch takes the half-fix path — it maps the direction through the viewpoint but keeps the swap. Running its approach against this fixture gives viewpoint 2 a battle score of `0.381`, i.e. viewpoint 1's score, so the pair no longer sums to 1 and every rating moves. That branch is superseded and can be deleted.

## Query cost

Selecting by the game row reaches `game_score.game`, so the two hot read paths (`WarriorArena.update_rating` and the warrior-arena page) prefetch `game_scores__game`. A test pins the query count against the *battle count* rather than against a number, so it survives unrelated query changes and still fails if a prefetch drops the game — verified failing at 10 vs 4 queries when the prefetch is removed.

## Also

Removes the resolved `TODO.md` entry and adds one for `GameScore.cooperation_score`, which has no test. Updates the now-stale references in `docs/game-migration.md`, `docs/battle-display.md` and `docs/data-model.md`.

One thing deliberately left alone: `Game` still has six near-identical properties that fetch `score_object`, None-check and delegate. Collapsing them is possible for the first time after this change, but `Game` is deleted wholesale in step 2, so it would be short-lived churn.

---
_Generated by [Claude Code](https://claude.ai/code/session_018VE3Xu8dy3mhiGoxDDDboZ)_